### PR TITLE
Kenny/glob

### DIFF
--- a/docs/source/basics/working_with_files.md
+++ b/docs/source/basics/working_with_files.md
@@ -85,6 +85,37 @@ to access these `local_path` and `remote_path` attributes directly:
 * Manually fetching additional files from s3 similar to a passed file's remote source.
 * Using the Latch SDK to list other files similar to a passed file (eg. `latch ls latch:///foo`)
 
+## Using Globs to Move Groups of Files
+
+Often times logic is needed to move groups of files together based on a shared
+pattern. For instance, you may wish to return all files that end with a
+`fastq.gz` extension after a
+[trimming](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-016-1069-7#:~:text=Trimming%20of%20adapter%20sequences%20from,previously%20published%20adapter%20trimming%20tools.)
+task has been run.
+
+To do this in the SDK, you can leverage the `file_glob` function to construct
+lists of `LachFile`s defined by a pattern.
+
+The class of allowed patterns are defined as
+[globs](https://en.wikipedia.org/wiki/Glob_(programming)). It is likely you've
+already used globs in the terminal by using wildcard characters in common
+commands, eg. `ls *.txt`.
+
+The second argument must be a valid latch URL pointing to a directory. This will
+be the remote location of returned `LatchFile` constructed with this utility.
+
+In this example, all files ending with `.fastq.gz` in the working directory of
+the task will be returned to the `latch:///fastqc_outputs` directory:
+
+```
+@small_task
+def task():
+
+    ...
+
+    return file_glob("*.fastq.gz", "latch:///fastqc_outputs")
+```
+
 ### `latch:///` URLs
 
 Recall that URLs (Uniform Resource Locators) describe the location of an object

--- a/latch/types/utils.py
+++ b/latch/types/utils.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from typing import List
+from urllib.parse import urlparse
+
+from latch.types import LatchFile
+
+
+def file_glob(pattern: str, remote_path: str) -> List[LatchFile]:
+    """Constructs a list of LatchFiles from a glob pattern.
+
+    Convenient utility for passing collections of files between taks. See
+    [nextflow's channels](https://www.nextflow.io/docs/latest/channel.html) or
+    [snakemake's wildcards](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#wildcards).
+    for similar functionality in other orchestration tools.
+
+    Args:
+        pattern: A glob pattern to match a set of files, eg. '*.py'. Will
+            resolve paths with respect to the working directory of the caller.
+        remote_path: A valid latch URL, eg. latch:///foo.txt.
+
+    Returns:
+        A list of instantiated LatchFile objects.
+
+    Intended Use: ::
+
+        @small_task
+        def task():
+
+            ...
+
+            return file_glob("*.fastq.gz", "latch:///fastqc_outputs")
+
+    """
+
+    _validate_latch_url(remote_path)
+    matched = sorted(Path(".").glob(pattern))
+    return [LatchFile(file, remote_path + file.name) for file in matched]
+
+
+class InvalidLatchURL(Exception):
+    pass
+
+
+def _validate_latch_url(url: str):
+
+    try:
+        parsed = urlparse(url)
+    except ValueError as e:
+        raise InvalidLatchURL(
+            f"{url} is not a valid url. See"
+            " https://docs.latch.bio/basics/working_with_files.html#latch-urls."
+        ) from e
+
+    if parsed.scheme != "latch":
+        raise InvalidLatchURL(
+            f"{url} is not a valid latch url - must use the 'latch' scheme. See"
+            " https://docs.latch.bio/basics/working_with_files.html#latch-urls."
+        )
+
+    if not parsed.path.startswith("/"):
+        raise InvalidLatchURL(
+            f"{url} is not a valid latch url - does not contain an absolute"
+            " path within the url. (It is common to forget the third backslash in"
+            " a the beginning of the string, eg.`latch: ///foobar.txt`, a"
+            " correctly formatted latch URL string.)"
+        )

--- a/latch/types/utils.py
+++ b/latch/types/utils.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from latch.types import LatchFile
 
 
-def file_glob(pattern: str, remote_path: str) -> List[LatchFile]:
+def file_glob(pattern: str, remote_directory: str) -> List[LatchFile]:
     """Constructs a list of LatchFiles from a glob pattern.
 
     Convenient utility for passing collections of files between taks. See
@@ -13,10 +13,15 @@ def file_glob(pattern: str, remote_path: str) -> List[LatchFile]:
     [snakemake's wildcards](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#wildcards).
     for similar functionality in other orchestration tools.
 
+    The remote location of each constructed LatchFile will be consructed by
+    appending the file name returned by the pattern to the directory
+    represented by the `remote_path`. Ensure that a valid direc
+
     Args:
         pattern: A glob pattern to match a set of files, eg. '*.py'. Will
             resolve paths with respect to the working directory of the caller.
-        remote_path: A valid latch URL, eg. latch:///foo.txt.
+        remote_directory: A valid latch URL pointing to a directory, eg.
+            latch:///foo. This _must_ be a directory and not a file.
 
     Returns:
         A list of instantiated LatchFile objects.
@@ -32,9 +37,9 @@ def file_glob(pattern: str, remote_path: str) -> List[LatchFile]:
 
     """
 
-    _validate_latch_url(remote_path)
+    _validate_latch_url(remote_directory)
     matched = sorted(Path(".").glob(pattern))
-    return [LatchFile(file, remote_path + file.name) for file in matched]
+    return [LatchFile(file, remote_directory + file.name) for file in matched]
 
 
 class InvalidLatchURL(Exception):

--- a/latch/types/utils.py
+++ b/latch/types/utils.py
@@ -1,27 +1,31 @@
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 
 from latch.types import LatchFile
 
 
-def file_glob(pattern: str, remote_directory: str) -> List[LatchFile]:
+def file_glob(
+    pattern: str, remote_directory: str, target_dir: Optional[Path] = None
+) -> List[LatchFile]:
     """Constructs a list of LatchFiles from a glob pattern.
 
-    Convenient utility for passing collections of files between taks. See
+    Convenient utility for passing collections of files between tasks. See
     [nextflow's channels](https://www.nextflow.io/docs/latest/channel.html) or
     [snakemake's wildcards](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#wildcards).
     for similar functionality in other orchestration tools.
 
     The remote location of each constructed LatchFile will be consructed by
     appending the file name returned by the pattern to the directory
-    represented by the `remote_path`. Ensure that a valid direc
+    represented by the `remote_directory`.
 
     Args:
         pattern: A glob pattern to match a set of files, eg. '*.py'. Will
             resolve paths with respect to the working directory of the caller.
         remote_directory: A valid latch URL pointing to a directory, eg.
             latch:///foo. This _must_ be a directory and not a file.
+        target_dir: An optional Path object to define an alternate working
+            directory for path resolution
 
     Returns:
         A list of instantiated LatchFile objects.
@@ -38,7 +42,13 @@ def file_glob(pattern: str, remote_directory: str) -> List[LatchFile]:
     """
 
     _validate_latch_url(remote_directory)
-    matched = sorted(Path(".").glob(pattern))
+
+    if target_dir is None:
+        wd = Path(".")
+    else:
+        wd = target_dir
+    matched = sorted(wd.glob(pattern))
+
     return [LatchFile(file, remote_directory + file.name) for file in matched]
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,20 @@
+import pytest
+
+from latch.types.utils import InvalidLatchURL, _validate_latch_url
+
+
+def test_validate_latch_url():
+    valid_urls = (
+        "latch:///foo.txt",
+        "latch:///foo/bar.txt",
+        "latch:///foo/bar/",
+        "latch:///foo/bar",
+    )
+    invalid_urls = ("latch://foo.txt", "lach:///foo.txt")
+
+    for url in valid_urls:
+        _validate_latch_url(url)
+
+    for url in invalid_urls:
+        with pytest.raises(InvalidLatchURL):
+            _validate_latch_url(url)


### PR DESCRIPTION
    Convenient utility for passing collections of files between taks. See
    [nextflow's channels](https://www.nextflow.io/docs/latest/channel.html) or
    [snakemake's wildcards](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#wildcards).
    for similar functionality in other orchestration tools.

    The remote location of each constructed LatchFile will be consructed by
    appending the file name returned by the pattern to the directory
    represented by the `remote_path`. Ensure that a valid direc

```
        @small_task
        def task():

            ...

            return file_glob("*.fastq.gz", "latch:///fastqc_outputs")
```