### PR TITLE
Added error message when initializing illegal workflow name

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,10 +1,6 @@
 name: Test
-on:
-  push:
-    branches:
-      - "main"
-      - "kenny/*"
-      - "ayush/*"
+on: [push, pull_request_target]
+
 jobs:
   macos:
     name: Test MacOs

--- a/latch/cli/main.py
+++ b/latch/cli/main.py
@@ -82,7 +82,7 @@ def init(pkg_name: str):
         return
     
     # Check for other illegal characters
-    if len(re.findall("(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*", pkg_name)) is not 1:
+    if len(re.findall("(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*", pkg_name)) != 1:
         click.secho(f"Unable to initialize {pkg_name}: package name must match the regular expression '(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*'", fg="red")
         click.secho("This means that the package name must start and end with a lower-case letter, and may contain hyphens, underscores, and periods", fg="red")
         return

--- a/latch/cli/main.py
+++ b/latch/cli/main.py
@@ -73,6 +73,17 @@ def init(pkg_name: str):
 
     Visit docs.latch.bio to learn more.
     """
+
+    #Workflow name must not contain capitals or end in a hyphen or underscore. If it does, we should throw an error
+    #Check for capitals
+    if any(char.isupper() for char in pkg_name):
+        click.secho(f"Unable to initialize {pkg_name}: package name must not contain any upper-case characters", fg="red")
+        return
+    
+    if pkg_name[-1] is '-' or pkg_name[-1] is '_':
+        click.secho(f"Unable to initialize {pkg_name}: package name must not end in a hyphen or underscore", fg="red")
+        return
+
     try:
         _init(pkg_name)
     except Exception as e:

--- a/latch/cli/main.py
+++ b/latch/cli/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Union
 
 import click
+import re
 
 from latch.services import cp as _cp
 from latch.services import execute as _execute
@@ -74,14 +75,16 @@ def init(pkg_name: str):
     Visit docs.latch.bio to learn more.
     """
 
-    #Workflow name must not contain capitals or end in a hyphen or underscore. If it does, we should throw an error
-    #Check for capitals
+    # Workflow name must not contain capitals or end in a hyphen or underscore. If it does, we should throw an error
+    # Check for capitals
     if any(char.isupper() for char in pkg_name):
         click.secho(f"Unable to initialize {pkg_name}: package name must not contain any upper-case characters", fg="red")
         return
     
-    if pkg_name[-1] is '-' or pkg_name[-1] is '_':
-        click.secho(f"Unable to initialize {pkg_name}: package name must not end in a hyphen or underscore", fg="red")
+    # Check for other illegal characters
+    if len(re.findall("(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*", pkg_name)) is not 1:
+        click.secho(f"Unable to initialize {pkg_name}: package name must match the regular expression '(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*'", fg="red")
+        click.secho("This means that the package name must start and end with a lower-case letter, and may contain hyphens, underscores, and periods", fg="red")
         return
 
     try:


### PR DESCRIPTION
Right now, you get a cryptic error message when you register a workflow with an illegal name (see #60). I've added a check when initializing a workflow that prints a clear error message if you attempt to initialize a workflow with an illegal name (I've defined an illegal name as anything with capital letters or that ends in _ or -, though this isn't exhaustive). I haven't tested this, since the repository doesn't give build instructions, but it's only three if statements. 