### PR TITLE
fix: stop unneeded download and reupload on files

### DIFF
--- a/latch/types/directory.py
+++ b/latch/types/directory.py
@@ -145,7 +145,9 @@ class LatchDirPathTransformer(FlyteDirToMultipartBlobTransformer):
         def _downloader():
             return ctx.file_access.get_data(uri, local_folder, is_multipart=True)
 
-        return LatchDir(local_folder, uri, downloader=_downloader)
+        ret = LatchDir(local_folder, uri, downloader=_downloader)
+        ret._remote_source = uri
+        return ret
 
 
 TypeEngine.register(LatchDirPathTransformer())

--- a/latch/types/file.py
+++ b/latch/types/file.py
@@ -146,7 +146,9 @@ class LatchFilePathTransformer(FlyteFilePathTransformer):
         def _downloader():
             return ctx.file_access.get_data(uri, local_path, is_multipart=False)
 
-        return LatchFile(local_path, uri, downloader=_downloader)
+        ret = LatchFile(local_path, uri, downloader=_downloader)
+        ret._remote_source = uri
+        return ret
 
 
 TypeEngine.register(LatchFilePathTransformer())


### PR DESCRIPTION
* Typically occurs when LatchFiles and LatchDirs passed as input to
a task are also included in the output (this is useful, i.e. when
preparing inputs for a map task).