### PR TITLE
Do not unnecessarily double-check directory creation

### DIFF
--- a/latch_cli/services/mkdir.py
+++ b/latch_cli/services/mkdir.py
@@ -49,13 +49,3 @@ def mkdir(remote_directory):
 
     if not json_data["success"]:
         raise ValueError(json_data["error"]["data"]["message"])
-
-    response = tinyrequests.post(
-        endpoints["verify"], headers=headers, json={"filename": remote_directory}
-    )
-    json_data = response.json()
-
-    if not json_data["success"]:
-        raise ValueError(json_data["error"]["data"]["message"])
-    elif not json_data["exists"]:
-        raise ValueError("Unable to create directory for some reason.")


### PR DESCRIPTION
The `mkdir` endpoint will report success/failure without the need to double-check the directory got created

This cuts out a round-trip + removes the need to keep `/verify` updated as we add new features. `/verify` could also be rewritten to properly use stored procedures but since it's kind of useless anyway I think it's better to just phase it out and eventually remove it entirely