### PR TITLE
Update local execute

### DIFF
--- a/docs/source/basics/local_development.md
+++ b/docs/source/basics/local_development.md
@@ -71,3 +71,33 @@ When a workflow is executing locally, remote path handling will be ignored. This
 means there will be no attempt to copy data from remote paths when ingesting or
 returning parameter values. Workflow logic will strictly read and write from the
 `local_path` property of the `LatchFile`/`LatchDir` type (first argument).
+
+## Outputs
+
+To save and view outputs during local execution, you have to store files locally and 
+then return either a `LatchFile` or `LatchDir` object pointing to that local path. Due to
+the way local-execute works under the hood, you have to return this in a specified 
+directory. This default directory is `/root/{output_dir}`, where `output_dir` is by default
+`'outputs'` and can be changed with the `--output-dir` flag.
+
+For example, if you run 
+```bash
+latch local-execute . --output-dir my_outputs
+```
+then in the workflow you will need to write output files and directories to `/root/my_outputs`.
+You don't technically need to return a `LatchFile` or `LatchDir` object pointing
+to `/root/my_outputs` during local execution to get the files, but your implementation
+should be consistent with how you would return a `LatchFile` or `LatchDir` object in the 
+LatchBio platform. For example, if you consistently write output files to `/root/my_outputs`, 
+then returning `LatchDir("/root/my_outputs", "latch:///my_outputs")` will have identical 
+behavior locally and in the LatchBio platform.
+
+
+## Versioning
+
+With local-execution, you are using images that you have built locally to test new workflow 
+code. This means that the only time you need to build a new image during local-execution is 
+when you make changes to that image. Generally this only applies if you are changing the
+dependencies downloaded or PATH in the image. If you do need to make a change but don't want
+to commit changes to the image on the LatchBio platform yet, use the `-u` or `--use-auto-version` 
+flag.

--- a/latch_cli/main.py
+++ b/latch_cli/main.py
@@ -1,5 +1,6 @@
 """Entrypoints to service functions through a latch_cli."""
 
+from dis import dis
 import re
 from collections import OrderedDict
 from pathlib import Path
@@ -271,11 +272,37 @@ def ls(group_directories_first: bool, remote_directories: Union[None, List[str]]
     """,
 )
 @click.argument("pkg_root", nargs=1, type=click.Path(exists=True))
-def local_execute(pkg_root: Path):
+@click.option(
+    "-u",
+    "--use-auto-version",
+    is_flag=True,
+    default=False,
+    type=bool,
+    help=(
+        "Whether to automatically bump the version of the workflow each time register"
+        " is called. This should only be used if you update the Dockerfile, but don't"
+        " want to permanently register those changes to Latch."
+    ),
+)
+@click.option(
+    "-o",
+    "--output-dir",
+    default="outputs",
+    type=str,
+    help=(
+        "The directory in which the outputs will be written to by the workflow. "
+        "(/root/{output_dir}). Defaults to 'outputs'."
+    )
+)
+def local_execute(pkg_root: Path, use_auto_version: bool, output_dir: str):
     from latch_cli.services.local_execute import local_execute
 
     try:
-        local_execute(Path(pkg_root).resolve())
+        local_execute(
+            Path(pkg_root).resolve(), 
+            use_auto_version=use_auto_version,
+            output_dir=output_dir
+        )
     except Exception as e:
         CrashReporter.report()
         click.secho(f"Unable to execute workflow: {str(e)}", fg="red")

--- a/latch_cli/services/register/register.py
+++ b/latch_cli/services/register/register.py
@@ -180,6 +180,8 @@ def register(
             register. The path can be absolute or relative. The path is always
             a directory, with its structure exactly as constructed and
             described in the `cli.services.init` function.
+        disable_auto_version: A bool indicating whether to disable the default
+            auto-versioning of the workflow.
 
 
     Example: ::


### PR DESCRIPTION
fix: update build_image call in local-execute to include new 'remote' flag, automatically set to False

fix/feat: change binding for local-execute in container to /root/local_execute instead of /root, as that caused loss of access to old files in /root, including dependencies. Added new binding for output folder for users to write to. 

feat: added cli flags for output_dir, use_auto_versioning. Set auto-versioning as opt-in, as the point of local-execute is to use existing images for faster development, and auto-versioning means you won't find a matching existing image.

docs: updated docs to reflect changes