### PR TITLE
fix: change binding of local code to container to /root/local_execute…

### DIFF
--- a/docs/source/basics/local_development.md
+++ b/docs/source/basics/local_development.md
@@ -71,3 +71,33 @@ When a workflow is executing locally, remote path handling will be ignored. This
 means there will be no attempt to copy data from remote paths when ingesting or
 returning parameter values. Workflow logic will strictly read and write from the
 `local_path` property of the `LatchFile`/`LatchDir` type (first argument).
+
+## Outputs
+
+To save and view outputs during local execution, you have to store files locally and 
+then return either a `LatchFile` or `LatchDir` object pointing to that local path. Due to
+the way local-execute works under the hood, you have to return this in a specified 
+directory. This default directory is `/root/{output_dir}`, where `output_dir` is by default
+`'outputs'` and can be changed with the `--output-dir` flag.
+
+For example, if you run 
+```bash
+latch local-execute . --output-dir my_outputs
+```
+then in the workflow you will need to write output files and directories to `/root/my_outputs`.
+You don't technically need to return a `LatchFile` or `LatchDir` object pointing
+to `/root/my_outputs` during local execution to get the files, but your implementation
+should be consistent with how you would return a `LatchFile` or `LatchDir` object in the 
+LatchBio platform. For example, if you consistently write output files to `/root/my_outputs`, 
+then returning `LatchDir("/root/my_outputs", "latch:///my_outputs")` will have identical 
+behavior locally and in the LatchBio platform.
+
+
+## Versioning
+
+With local-execution, you are using images that you have built locally to test new workflow 
+code. This means that the only time you need to build a new image during local-execution is 
+when you make changes to that image. Generally this only applies if you are changing the
+dependencies downloaded or PATH in the image. If you do need to make a change but don't want
+to commit changes to the image on the LatchBio platform yet, use the `-u` or `--use-auto-version` 
+flag.

--- a/docs/source/basics/local_development.md
+++ b/docs/source/basics/local_development.md
@@ -74,7 +74,7 @@ When a workflow is executing locally, folders named `mock_latch` and `mock_s3`
 will be mounted into the container, and created if they don't exist yet. These folders
 will be local versions of `latch:///` and `s3://` respectively. For example, if you 
 want to test a workflow using a LatchFile 'data.txt' as input, you can place the file
-in `my_workflow/mock_latch/data.txt` and pass the path to the workflow as `latch:///data.txt`.
+in `my_workflow/mock_latch/data.txt` and pass the file to the workflow as `LatchFile('latch:///data.txt')`.
 Similarly, if you are returning or creating LatchFiles or LatchDirs in your tasks or workflows,
 they will be created in these `mock_latch` and `mock_s3` folders. For example, if your workflow
 returns `LatchDir('outputs', 'latch:///outputs')`, the outputs will be created in

--- a/docs/source/subcommands.md
+++ b/docs/source/subcommands.md
@@ -90,7 +90,7 @@ Execute a workflow within the latest registered container. Run from the
 outside the pkg root, eg. `latch local-execute myworkflow` where
 `myworkflow` is the directory containing your workflow package.
 
-This is the same as running `$ python3 wf/__init__.py` within the latest
+This is the same as running `$ python -c "from wf import main; main()"` within the latest
 registered container. Workflow code is overlayed on the latest registered
 container as a volume available at container runtime, meaning that changes to
 python code do not require full Docker rebuilds. This is ideal for rapid local
@@ -101,7 +101,7 @@ As an aside, we assume the workflow file contains a snippet conducive to local
 execution such as:
 
 ```python
-    if __name__ == "__main___":
+    def main():
        my_workflow(a="foo", reads=LatchFile("/users/von/neumann/machine.txt")
 ```
 

--- a/latch_cli/main.py
+++ b/latch_cli/main.py
@@ -271,7 +271,8 @@ def ls(group_directories_first: bool, remote_directories: Union[None, List[str]]
     about local development.
     """,
 )
-@click.argument("pkg_root", nargs=1, type=click.Path(exists=True))@click.option(
+@click.argument("pkg_root", nargs=1, type=click.Path(exists=True))
+@click.option(
     "-u",
     "--use-auto-version",
     is_flag=True,
@@ -286,11 +287,12 @@ def ls(group_directories_first: bool, remote_directories: Union[None, List[str]]
 @click.option(
     "-o",
     "--output-dir",
-    default="outputs",
-    type=str,
+    default=Path("/root/outputs"),
+    type=click.Path(),
     help=(
-        "The directory in which the outputs will be written to by the workflow. "
-        "(/root/{output_dir}). Defaults to 'outputs'."
+        "The directory in which the outputs will be written to within the workflow. "
+        "Defaults to '/root/outputs'. These outputs can be seen locally in the 'outputs' "
+        "directory."
     )
 )
 def local_execute(pkg_root: Path, use_auto_version: bool, output_dir: str):

--- a/latch_cli/main.py
+++ b/latch_cli/main.py
@@ -264,7 +264,7 @@ def ls(group_directories_first: bool, remote_directories: Union[None, List[str]]
     Assuming this file contains a snippet conducive to local execution such as:
 
     \b
-        {ac.bold}if __name__ == "__main___":
+        {ac.bold}def main():
            my_workflow(a="foo", reads=LatchFile("/users/von/neuman/machine.txt"){ac.reset}
 
     Visit {ac.underline}https://docs.latch.bio/basics/local_development.html{ac.no_underline} to read more
@@ -284,7 +284,7 @@ def ls(group_directories_first: bool, remote_directories: Union[None, List[str]]
         " want to permanently register those changes to Latch."
     ),
 )
-def local_execute(pkg_root: Path, use_auto_version: bool, output_dir: str):
+def local_execute(pkg_root: Path, use_auto_version: bool):
     from latch_cli.services.local_execute import local_execute
 
     try:

--- a/latch_cli/main.py
+++ b/latch_cli/main.py
@@ -271,12 +271,37 @@ def ls(group_directories_first: bool, remote_directories: Union[None, List[str]]
     about local development.
     """,
 )
-@click.argument("pkg_root", nargs=1, type=click.Path(exists=True))
-def local_execute(pkg_root: Path):
+@click.argument("pkg_root", nargs=1, type=click.Path(exists=True))@click.option(
+    "-u",
+    "--use-auto-version",
+    is_flag=True,
+    default=False,
+    type=bool,
+    help=(
+        "Whether to automatically bump the version of the workflow each time register"
+        " is called. This should only be used if you update the Dockerfile, but don't"
+        " want to permanently register those changes to Latch."
+    ),
+)
+@click.option(
+    "-o",
+    "--output-dir",
+    default="outputs",
+    type=str,
+    help=(
+        "The directory in which the outputs will be written to by the workflow. "
+        "(/root/{output_dir}). Defaults to 'outputs'."
+    )
+)
+def local_execute(pkg_root: Path, use_auto_version: bool, output_dir: str):
     from latch_cli.services.local_execute import local_execute
 
     try:
-        local_execute(Path(pkg_root).resolve())
+        local_execute(
+            Path(pkg_root).resolve(), 
+            use_auto_version=use_auto_version,
+            output_dir=output_dir
+        )
     except Exception as e:
         CrashReporter.report()
         click.secho(f"Unable to execute workflow: {str(e)}", fg="red")

--- a/latch_cli/main.py
+++ b/latch_cli/main.py
@@ -284,17 +284,6 @@ def ls(group_directories_first: bool, remote_directories: Union[None, List[str]]
         " want to permanently register those changes to Latch."
     ),
 )
-@click.option(
-    "-o",
-    "--output-dir",
-    default=Path("/root/outputs"),
-    type=click.Path(),
-    help=(
-        "The directory in which the outputs will be written to within the workflow. "
-        "Defaults to '/root/outputs'. These outputs can be seen locally in the 'outputs' "
-        "directory."
-    )
-)
 def local_execute(pkg_root: Path, use_auto_version: bool, output_dir: str):
     from latch_cli.services.local_execute import local_execute
 
@@ -302,7 +291,6 @@ def local_execute(pkg_root: Path, use_auto_version: bool, output_dir: str):
         local_execute(
             Path(pkg_root).resolve(), 
             use_auto_version=use_auto_version,
-            output_dir=output_dir
         )
     except Exception as e:
         CrashReporter.report()

--- a/latch_cli/services/local_execute.py
+++ b/latch_cli/services/local_execute.py
@@ -1,12 +1,97 @@
 """Service to execute a workflow in a container."""
 
 from pathlib import Path
+import os
+import sys
+from typing import Optional, Tuple, Generator
+from distutils import dir_util
+from shutil import copyfile
 
 import docker.errors
 
 from latch_cli.services.register import RegisterCtx, _print_build_logs, build_image
-from flytekit.core.context_manager import FlyteContext, FlyteContextManager
+from flytekit.core.context_manager import FlyteContextManager
+from flytekit.core.data_persistence import DataPersistence, DataPersistencePlugins
 
+class LocalExecutePersistence(DataPersistence):
+    """
+    The simplest form of persistence that is available with default flytekit - Disk-based persistence.
+    This will store all data locally and retrieve the data from local. This is helpful for local execution and simulating
+    runs.
+    Local persistence to mock latch:/// and s3:// retrieval and storage during local execution.
+    PROTOCOL: latch:/// or s3://
+    """
+
+    def __init__(self, default_prefix: Optional[str] = None, **kwargs):
+        super().__init__(name='local-execute', default_prefix=default_prefix, **kwargs)
+
+    @staticmethod
+    def _make_local_path(path):
+        if not os.path.exists(path):
+            try:
+                Path(path).mkdir(parents=True, exist_ok=True)
+            except OSError:  # Guard against race condition
+                if not os.path.isdir(path):
+                    raise
+
+    def strip_file_header(self, path: str) -> str:
+        """
+        Drops latch:/// or s3:// if it exists from the file
+        """
+        for protocol, prefix in [('latch://', '/root/mock_latch/'), 
+                                 ('s3://', '/root/mock_s3/')]:
+            if path.startswith(protocol):
+                return path.replace(protocol, prefix, 1)
+        return path
+
+    def listdir(self, path: str, recursive: bool = False) -> Generator[str, None, None]:
+        if not recursive:
+            files = os.listdir(self.strip_file_header(path))
+            for f in files:
+                yield f
+            return
+
+        for root, subdirs, files in os.walk(self.strip_file_header(path)):
+            for f in files:
+                yield os.path.join(root, f)
+        return
+
+    def exists(self, path: str):
+        return os.path.exists(self.strip_file_header(path))
+
+    def get(self, from_path: str, to_path: str, recursive: bool = False):
+        if from_path != to_path:
+            if recursive:
+                dir_util.copy_tree(self.strip_file_header(from_path), self.strip_file_header(to_path))
+            else:
+                copyfile(self.strip_file_header(from_path), self.strip_file_header(to_path))
+
+    def put(self, from_path: str, to_path: str, recursive: bool = False):
+        if from_path != to_path:
+            if recursive:
+                dir_util.copy_tree(self.strip_file_header(from_path), self.strip_file_header(to_path))
+            else:
+                # Emulate s3's flat storage by automatically creating directory path
+                self._make_local_path(os.path.dirname(self.strip_file_header(to_path)))
+                # Write the object to a local file in the temp local folder
+                copyfile(self.strip_file_header(from_path), self.strip_file_header(to_path))
+
+    def construct_path(self, _: bool, add_prefix: bool, *args: str) -> str:
+        # Ignore add_protocol for now. Only complicates things
+        if add_prefix:
+            prefix = self.default_prefix if self.default_prefix else ""
+            return os.path.join(prefix, *args)
+        return os.path.join(*args)
+
+# def create_latch_s3_paths() -> Tuple[str, str]:
+#     flyte_ctx = FlyteContextManager.current_context()
+#     mock_latch_path = flyte_ctx.file_access.get_random_local_directory()
+#     mock_s3_path = flyte_ctx.file_access.get_random_local_directory()
+#     return mock_latch_path, mock_s3_path
+
+def prep_container_for_local_exec():
+    DataPersistencePlugins.register_plugin("latch://", LocalExecutePersistence, force=True)
+    DataPersistencePlugins.register_plugin("s3://", LocalExecutePersistence, force=True)
 
 def local_execute(
     pkg_root: Path, 
@@ -35,7 +120,6 @@ def local_execute(
         $ latch local-execute myworkflow
         # Where `myworkflow` is a directory with workflow code.
     """
-
     ctx = RegisterCtx(pkg_root, disable_auto_version=(not use_auto_version))
 
     dockerfile = ctx.pkg_root.joinpath("Dockerfile")
@@ -44,8 +128,13 @@ def local_execute(
         # Copy contents of workflow package to container's root directory to 
         # emulate natve workflow execution, rather than running from 
         # /root/local_execute, and rather than binding to /root.
-        cmd = f"cp -r /root/local_execute/!({output_dir.stem}) /root ;" + \
-              "python3 /root/wf/__init__.py"
+        # Then call local_execute module to register the local latch/s3 plugins.
+        # TODO: Figure out how to do this without hard-coding mock_latch, mock_s3 paths
+        cmd =   "cp -r /root/local_execute/!(mock_latch|mock_s3) /root ;" + \
+                "python3 -c " + \
+                "'from latch_cli.services.local_execute import prep_container_for_local_exec; " + \
+                "prep_container_for_local_exec();" + \
+                "from wf import main; main();'"
         container = ctx.dkr_client.create_container(
             image_name,
             command=["bash", "-O", "extglob", "-c", cmd],
@@ -56,8 +145,12 @@ def local_execute(
                         "bind": "/root/local_execute",
                         "mode": "rw",
                     },
-                    str(ctx.pkg_root.joinpath('outputs')): {
-                        "bind": output_dir,
+                    str(ctx.pkg_root.joinpath('mock_latch')): {
+                        "bind": '/root/mock_latch',
+                        "mode": "rw",
+                    },
+                    str(ctx.pkg_root.joinpath('mock_s3')): {
+                        "bind": '/root/mock_s3',
                         "mode": "rw",
                     },
                 }

--- a/latch_cli/services/local_execute.py
+++ b/latch_cli/services/local_execute.py
@@ -7,7 +7,11 @@ import docker.errors
 from latch_cli.services.register import RegisterCtx, _print_build_logs, build_image
 
 
-def local_execute(pkg_root: Path):
+def local_execute(
+    pkg_root: Path, 
+    use_auto_version: bool,
+    output_dir: str,
+) -> None:
     """Executes a workflow locally within its latest registered container.
 
     Will stream in-container local execution stdout to terminal from which the
@@ -15,7 +19,14 @@ def local_execute(pkg_root: Path):
 
     Args:
         pkg_root: A path pointing to to the workflow package to be executed
-        locally.
+            locally.
+        use_auto_version: A bool indicating whether to use the default
+            auto-versioning of the workflow. Recommended to be set to False for
+            local execution so that previous images can be reused. Only really need
+            to set to True for local execution if you update the Dockerfile.
+        output_dir: The name of the output directory that the workflow writes to.
+            In the workflow that means it will write to /root/{output_dir}.
+
 
     Example: ::
 
@@ -23,23 +34,33 @@ def local_execute(pkg_root: Path):
         # Where `myworkflow` is a directory with workflow code.
     """
 
-    ctx = RegisterCtx(pkg_root)
+    ctx = RegisterCtx(pkg_root, disable_auto_version=(not use_auto_version))
 
     dockerfile = ctx.pkg_root.joinpath("Dockerfile")
 
     def _create_container(image_name: str):
+        # Copy contents of workflow package to container's root directory to 
+        # emulate natve workflow execution, rather than running from 
+        # /root/local_execute, and rather than binding to /root.
+        cmd = f"cp -r /root/local_execute/!({output_dir}) /root ;" + \
+              "python3 /root/wf/__init__.py"
         container = ctx.dkr_client.create_container(
             image_name,
-            command=["python3", "/root/wf/__init__.py"],
+            command=["bash", "-O", "extglob", "-c", cmd],
             volumes=[str(ctx.pkg_root)],
             host_config=ctx.dkr_client.create_host_config(
                 binds={
                     str(ctx.pkg_root): {
-                        "bind": "/root",
+                        "bind": "/root/local_execute",
+                        "mode": "rw",
+                    },
+                    str(ctx.pkg_root.joinpath(output_dir)): {
+                        "bind": f"/root/{output_dir}",
                         "mode": "rw",
                     },
                 }
             ),
+            working_dir="/root",
         )
         return container
 


### PR DESCRIPTION
… to prevent loss of packages/resources installed in /root, feat: add option to use image auto_versioning for local_execute with default to False, feat: add output dir, feat: add cli args for image auto_versioning and output_dir name, docs: update docs to accomodate changes