### PR TITLE
consistent json repr

### DIFF
--- a/latch/types/directory.py
+++ b/latch/types/directory.py
@@ -56,10 +56,15 @@ class LatchDir(FlyteDirectory):
         remote_path: Optional[PathLike] = None,
         **kwargs,
     ):
+
+        # Cast PathLike objects so that LatchDir has consistent JSON
+        # representation.
+        self.path = str(path)
+
         if _is_valid_url(path) and remote_path is None:
-            self._remote_directory = path
+            self._remote_directory = str(path)
         else:
-            self._remote_directory = remote_path
+            self._remote_directory = str(remote_path)
 
         if kwargs.get("downloader") is not None:
             super().__init__(path, kwargs["downloader"], remote_path)

--- a/latch/types/directory.py
+++ b/latch/types/directory.py
@@ -105,7 +105,10 @@ class LatchDir(FlyteDirectory):
         return self._remote_directory
 
     def __str__(self):
-        return f'LatchDir("{self.remote_path}")'
+        if self.remote_path is None:
+            return "LatchDir()"
+        else:
+            return f'LatchDir("{self.remote_path}")'
 
 
 LatchOutputDir = Annotated[

--- a/latch/types/directory.py
+++ b/latch/types/directory.py
@@ -57,6 +57,9 @@ class LatchDir(FlyteDirectory):
         **kwargs,
     ):
 
+        if path is None:
+            raise ValueError("Unable to instantiate LatchDir with None")
+
         # Cast PathLike objects so that LatchDir has consistent JSON
         # representation.
         self.path = str(path)

--- a/latch/types/directory.py
+++ b/latch/types/directory.py
@@ -104,11 +104,15 @@ class LatchDir(FlyteDirectory):
         """A url referencing in object in LatchData or s3."""
         return self._remote_directory
 
+    def __repr__(self):
+        if self.remote_path is None:
+            return f'LatchDir("{self.local_path}")'
+        return f'LatchDir("{self.local_path}", remote_path="{self.remote_path}")'
+
     def __str__(self):
         if self.remote_path is None:
             return "LatchDir()"
-        else:
-            return f'LatchDir("{self.remote_path}")'
+        return f'LatchDir("{self.remote_path}")'
 
 
 LatchOutputDir = Annotated[

--- a/latch/types/directory.py
+++ b/latch/types/directory.py
@@ -67,7 +67,7 @@ class LatchDir(FlyteDirectory):
         if _is_valid_url(path) and remote_path is None:
             self._remote_directory = str(path)
         else:
-            self._remote_directory = str(remote_path)
+            self._remote_directory = None if remote_path is None else str(remote_path)
 
         if kwargs.get("downloader") is not None:
             super().__init__(path, kwargs["downloader"], remote_path)

--- a/latch/types/file.py
+++ b/latch/types/file.py
@@ -104,11 +104,15 @@ class LatchFile(FlyteFile):
         """A url referencing in object in LatchData or s3."""
         return self._remote_path
 
+    def __repr__(self):
+        if self.remote_path is None:
+            return f'LatchFile("{self.local_path}")'
+        return f'LatchFile("{self.local_path}", remote_path="{self.remote_path}")'
+
     def __str__(self):
         if self.remote_path is None:
             return "LatchFile()"
-        else:
-            return f'LatchFile("{self.remote_path}")'
+        return f'LatchFile("{self.remote_path}")'
 
 
 LatchOutputFile = Annotated[

--- a/latch/types/file.py
+++ b/latch/types/file.py
@@ -67,7 +67,7 @@ class LatchFile(FlyteFile):
         if _is_valid_url(path) and remote_path is None:
             self._remote_path = str(path)
         else:
-            self._remote_path = str(remote_path)
+            self._remote_path = None if remote_path is None else str(remote_path)
 
         if kwargs.get("downloader") is not None:
             super().__init__(path, kwargs["downloader"], remote_path)

--- a/latch/types/file.py
+++ b/latch/types/file.py
@@ -105,7 +105,10 @@ class LatchFile(FlyteFile):
         return self._remote_path
 
     def __str__(self):
-        return f'LatchFile("{self.remote_path}")'
+        if self.remote_path is None:
+            return "LatchFile()"
+        else:
+            return f'LatchFile("{self.remote_path}")'
 
 
 LatchOutputFile = Annotated[

--- a/latch/types/file.py
+++ b/latch/types/file.py
@@ -54,13 +54,17 @@ class LatchFile(FlyteFile):
     def __init__(
         self,
         path: Union[str, PathLike],
-        remote_path: Optional[PathLike] = None,
+        remote_path: Optional[Union[str, PathLike]] = None,
         **kwargs,
     ):
+        # Cast PathLike objects so that LatchFile has consistent JSON
+        # representation.
+        self.path = str(path)
+
         if _is_valid_url(path) and remote_path is None:
-            self._remote_path = path
+            self._remote_path = str(path)
         else:
-            self._remote_path = remote_path
+            self._remote_path = str(remote_path)
 
         if kwargs.get("downloader") is not None:
             super().__init__(path, kwargs["downloader"], remote_path)

--- a/latch/types/file.py
+++ b/latch/types/file.py
@@ -57,6 +57,9 @@ class LatchFile(FlyteFile):
         remote_path: Optional[Union[str, PathLike]] = None,
         **kwargs,
     ):
+        if path is None:
+            raise ValueError("Unable to instantiate LatchFile with None")
+
         # Cast PathLike objects so that LatchFile has consistent JSON
         # representation.
         self.path = str(path)


### PR DESCRIPTION
```
@dataclass
@dataclass_json
class Foo():
    a: LatchFile

one = Foo(a=LatchFile("/tmp/sample.txt").to_json()
two = Foo(a=LatchFile=(Path("/tmp/sample.txt")).to_json()
```

`one` and `two` have different serialized representations that throw off the typetransformer. we consider these to be the same values