### PR TITLE
Fixed mkdir invalid argument error when registering workflow

### DIFF
--- a/latch_cli/services/register/register.py
+++ b/latch_cli/services/register/register.py
@@ -58,9 +58,10 @@ def _print_window(curr_lines: List[str], line: str):
 def _print_and_save_build_logs(build_logs, image: str, pkg_root: Path):
     print(f"Building Docker image for {image}")
 
-    os.makedirs(str(pkg_root) + f"/.logs/{image}", exist_ok=True)
+    # Not sure if I should change the value of `image` or not
+    os.makedirs(str(pkg_root) + f"/.logs/{image.replace(':', '_')}", exist_ok=True)
     with open(
-        str(pkg_root) + f"/.logs/{image}/docker-build-logs.txt", "w"
+        str(pkg_root) + f"/.logs/{image.replace(':', '_')}/docker-build-logs.txt", "w"
     ) as save_file:
         r = re.compile("^Step [0-9]+/[0-9]+ :")
         curr_lines = []

--- a/latch_cli/services/register/register.py
+++ b/latch_cli/services/register/register.py
@@ -58,8 +58,8 @@ def _print_window(curr_lines: List[str], line: str):
 def _print_and_save_build_logs(build_logs, image: str, pkg_root: Path):
     print(f"Building Docker image for {image}")
 
-    # Not sure if I should change the value of `image` or not
-    os.makedirs(str(pkg_root) + f"/.logs/{image.replace(':', '_')}", exist_ok=True)
+    logs_path = Path(pkg_root).joinpath(".logs").joinpath(image).resolve()
+    logs_path.mkdir(exist_ok=True)
     with open(
         str(pkg_root) + f"/.logs/{image.replace(':', '_')}/docker-build-logs.txt", "w"
     ) as save_file:

--- a/latch_cli/services/register/register.py
+++ b/latch_cli/services/register/register.py
@@ -61,7 +61,7 @@ def _print_and_save_build_logs(build_logs, image: str, pkg_root: Path):
     logs_path = Path(pkg_root).joinpath(".logs").joinpath(image).resolve()
     logs_path.mkdir(exist_ok=True)
     with open(
-        str(pkg_root) + f"/.logs/{image.replace(':', '_')}/docker-build-logs.txt", "w"
+        logs_path.joinpath("docker-build-logs.txt"), "w"
     ) as save_file:
         r = re.compile("^Step [0-9]+/[0-9]+ :")
         curr_lines = []


### PR DESCRIPTION
I had a bug where workflow registration would fail while creating a log directory and log file because linux (or at least Ubuntu) doesn't allow colons in file names. This change fixes that by replacing the colons in the log path with underscores. I've attached the error logs and a screenshot of the error. 

![image](https://user-images.githubusercontent.com/80700901/197404403-b8a2076e-0051-4d0c-9eac-cee02abb5c24.png)
[.latch_report.tar.gz](https://github.com/latchbio/latch/files/9847043/default.latch_report.tar.gz)
