### PR TITLE
added functionality to latch test-data upload

### DIFF
--- a/latch_cli/main.py
+++ b/latch_cli/main.py
@@ -507,6 +507,11 @@ def test_data(ctx):
 @test_data.command("upload")
 @click.argument("src_path", nargs=1, type=click.Path(exists=True))
 @click.option(
+    "--s3_path", 
+    default = None, 
+    type=str,
+    help=("Destination folder path to write to on s3 (omit s3 Bucket prefix)."))
+@click.option(
     "--dont-confirm-overwrite",
     "-d",
     is_flag=True,
@@ -514,13 +519,13 @@ def test_data(ctx):
     type=bool,
     help=("Automatically overwrite any files without asking for confirmation."),
 )
-def test_data_upload(src_path: str, dont_confirm_overwrite: bool):
+def test_data_upload(src_path: str, s3_path: str, dont_confirm_overwrite: bool):
     """Upload test data object."""
 
     from latch_cli.services.test_data.upload import upload
 
     try:
-        s3_url = upload(src_path, dont_confirm_overwrite)
+        s3_url = upload(src_path, s3_path, dont_confirm_overwrite)
         click.secho(f"Successfully uploaded to {s3_url}", fg="green")
     except Exception as e:
         CrashReporter.report()

--- a/latch_cli/services/test_data/upload.py
+++ b/latch_cli/services/test_data/upload.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import boto3
 import botocore
 import click
+import os
 
 from latch_cli.services.test_data.utils import _retrieve_creds
 from latch_cli.utils import account_id_from_token, retrieve_or_login
@@ -12,7 +13,7 @@ from latch_cli.utils import account_id_from_token, retrieve_or_login
 BUCKET = "latch-public"
 
 
-def upload(src_path: str, dont_confirm_overwrite: bool = True) -> str:
+def upload(src_path: str, s3_path: str = None, dont_confirm_overwrite: bool = True) -> str:
     """Uploads a local file/folder to a managed bucket.
 
     Args:
@@ -39,7 +40,10 @@ def upload(src_path: str, dont_confirm_overwrite: bool = True) -> str:
     if account_id is None or account_id == "":
         account_id = account_id_from_token(retrieve_or_login())
 
-    allowed_key = str((Path("test-data") / account_id).joinpath(src_path))
+    if s3_path is None:
+        allowed_key = str((Path("test-data") / account_id).joinpath(src_path))
+    else:
+        allowed_key = str((Path("test-data") / account_id).joinpath(s3_path))
 
     upload_helper(
         Path(src_path).resolve(),


### PR DESCRIPTION
Added the option to specify a destination folder on s3 when uploading test-data.

For example: `latch test-data upload./matrix.mtx --s3_path test/matrix.mtx` will write to `s3://latch-public/test-data/4751/test/matrix.mtx`.

If you don't specify `--s3_path`, it will write to the same path as the local path. Default functionality remains the same.