### PR TITLE
Improve example for dockerfile-per-task

### DIFF
--- a/docs/source/basics/customizing_interface.md
+++ b/docs/source/basics/customizing_interface.md
@@ -263,7 +263,7 @@ def wf(read1: LatchFile):
     ...
 ```
 
-### How Python types of paramters translate to the UI
+### How Python types of parameters translate to the UI
 
 Latch parses the Python type of your workflow parameters to generate the appropriate interface.
 

--- a/docs/source/basics/defining_cloud_resources.md
+++ b/docs/source/basics/defining_cloud_resources.md
@@ -17,7 +17,7 @@ represented as decorators:
 
 * `small_task`: 2 cpus, 4 gigs of memory, 0 gpus
 * `medium_task`: 32 cpus, 128 gigs of memory, 0 gpus
-* `large_task`: 96 cpus, 192 gig sof memory, 0 gpus
+* `large_task`: 96 cpus, 192 gigs of memory, 0 gpus
 * `small_gpu_task`: 8 cpus, 32 gigs of memory, 1 gpu (24 gigs of VRAM, 9,216 cuda cores)
 * `large_gpu_task`: 31 cpus, 120 gigs of memory, 1 gpu (24 gigs of VRAM, 9,216 cuda cores)
 

--- a/docs/source/basics/working_with_files.md
+++ b/docs/source/basics/working_with_files.md
@@ -86,7 +86,6 @@ Case 2: there is an existing 'test.txt' file in the LatchDir.
 ├── test.txt [Creation Time: 1/1/2022, 01:00:00 AM]
              [Last Modified: 1/1/2022, 23:00:00 AM]
 ```
-```
 
 ## Local Paths and Remote Paths
 

--- a/docs/source/examples/workflows_examples.md
+++ b/docs/source/examples/workflows_examples.md
@@ -15,7 +15,7 @@ We'll maintain a growing list of well documented examples developed by our commu
 **Phylogenetics**
   * [Seq-to-tree: Evolutionary history inference](https://github.com/JLSteenwyk/latch_wf_seq_to_tree)
   * [Codon optimization estimation](https://github.com/JLSteenwyk/latch_wf_codon_optimization)
-  * [Metamage: Taxonomy classification](https://github.com/jvfe/metamage_latch)
+  * [Metamage: Metagenomics assembly and annotation](https://github.com/jvfe/metamage_latch)
 
 **Single-cell Analysis**
   * [ArchR: Single-cell chromatin accessibility analysis](https://github.com/aa20g217/Archr-Latch-Wf)

--- a/docs/source/tutorials/metamage.md
+++ b/docs/source/tutorials/metamage.md
@@ -1,4 +1,4 @@
-# Taxonomy Classification with Metamage Workflow
+# Metagenomics assembly and annotation with Metamage Workflow
 
 In this tutorial, we will use the Latch SDK to build **metamage**, a workflow for taxonomic classification, assembly, binning and annotation of short-read host-associated metagenomics datasets.
 
@@ -80,10 +80,10 @@ metamage_latch
     ├── docs.py
     ├── functional.py
     ├── functional_module
-    │   ├── amp.py
-    │   ├── arg.py
-    │   ├── bgc.py
-    │   └── prodigal.py
+    │   ├── amp.py
+    │   ├── arg.py
+    │   ├── bgc.py
+    │   └── prodigal.py
     ├── host_removal.py
     ├── kaiju.py
     ├── metassembly.py


### PR DESCRIPTION
- Expands example in the dockerfile-per-task section
- Fixes a typo / Fixes title/description for one of my workflows

Improves the example for the dockerfile-per-task feature in the "Writing Dockerfiles" section.
Showing the content of each Dockerfile and explaining the directory structure chosen for the workflow.