### PR TITLE
use a version of `requests` that supports the version of `chardset` it installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ Types of changes
 
 * Removed a broken SDK test (launching CRISPResso2)
 
-### Bug Fixes
+### Fixed
 
 * `lytekit` version updated to pin `numpy` to version `1.22` (breaking changes in later versions of this library)
+* `requests` library given higher lower bound to fix warning with one of its dependencies
 * `latch get-params` will escape class attribute names (representation of Enum type) if they are python keywords 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "aioconsole==0.5.1",
         "kubernetes>=24.2.0",
         "pyjwt>=0.2.0",
-        "requests>=2.0",
+        "requests>=2.28.1",
         "click>=8.0",
         "docker>=5.0",
         "paramiko>=2.11.0",


### PR DESCRIPTION
gets rid of annoying warning on any subcommand that makes a request:

```
/root/miniconda/envs/jupyterlab/lib/python3.9/site-packages/requests/__init__.py:104: RequestsDependencyWarning: urllib3 (1.26.9) or chardet (5.1.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
```

- https://github.com/psf/requests/releases/tag/v2.28.1
- https://github.com/psf/requests/issues/6177

