### PR TITLE
allow imports that subclass from nested imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,5 @@ Types of changes
   potential mistakes arising from misspelling, and gives the benefit of IDE
   intellisense.
 * Made both configs singletons.
+* Fixed issue with registering libraries containing nested imports used as
+    subclasses (eg. `torch`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,5 +60,10 @@ Types of changes
   potential mistakes arising from misspelling, and gives the benefit of IDE
   intellisense.
 * Made both configs singletons.
+
+## 2.10.1 - 2023-01-18
+
+### Fixed
+
 * Fixed issue with registering libraries containing nested imports used as
     subclasses (eg. `torch`)

--- a/latch_cli/centromere/utils.py
+++ b/latch_cli/centromere/utils.py
@@ -32,35 +32,30 @@ def _import_flyte_objects(paths: List[Path], module_name: str = "wf"):
 
     with _add_sys_paths(paths):
 
-        # (kenny) Documenting weird failure modes of importing modules:
-        #   1. Calling attribute of FakeModule in some nested import
-        #
-        #   ```
-        #   # This is submodule or nested import of top level import
-        #   import foo
-        #   def new_func(a=foo.something):
-        #       ...
-        #   ```
-        #
-        #   The potentially weird workaround is to silence attribute
-        #   errors during import, which I don't see as swallowing problems
-        #   associated with the strict task here of retrieving attributes
-        #   from tasks, but idk.
-        #
-        #   2. Calling FakeModule directly in nested import
-        #
-        #   ```
-        #   # This is submodule or nested import of top level import
-        #   from foo import bar
-        #
-        #   a = bar()
-        #   ```
-        #
-        #   This is why we return a callable from our FakeModule
-
         class FakeModule(ModuleType):
             def __getattr__(self, key):
-                return lambda: None
+                # This value is designed to be used in the execution of top
+                # level code without throwing errors but need not do anything.
+                # Here are some cases where this value can be used:
+                #
+                # ```
+                # from foo import bar
+                #
+                # # Referencing an attribute from an attribute
+                # a = bar.x
+                #
+                # # Calling an attribute
+                # b = bar()
+                #
+                # # Subclassing from an attribute
+                # class C(bar):
+                # ```
+                #     ...
+                class FakeAttr:
+                    def __new__(*args, **kwargs):
+                        return None
+
+                return FakeAttr
 
             __all__ = []
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if CURRENT_PYTHON < MIN_PYTHON_VERSION:
 
 setup(
     name="latch",
-    version="v2.10.0",
+    version="v2.10.1",
     author_email="kenny@latch.bio",
     description="The Latchbio SDK",
     packages=find_packages(),


### PR DESCRIPTION
Fixes case when library code uses a fake import as a subclass, eg in torch:

```
--Traceback (most recent call last)--
/Users/nsofroniew/opt/anaconda3/envs/latch/lib/python3.9/site-packages/torch/jit/_monkeytype_config.py:73 in <module>
  71| if _IS_MONKEYTYPE_INSTALLED:
  72|
> 73|     class JitTypeTraceStoreLogger(CallTraceStoreLogger):
  74|         """A JitTypeCallTraceLogger that stores logged traces in a CallTraceStore."""
  75|         def __init__(self, store: CallTraceStore):
  76|             super().__init__(store)
  77|
```