### PR TITLE
fix: readonly permission errors

### DIFF
--- a/latch_cli/config/user.py
+++ b/latch_cli/config/user.py
@@ -25,14 +25,18 @@ class _UserConfig:
     def token_path(self):
         if self._token_path is None:
             self._token_path = self.root / "token"
-        self._token_path.touch(exist_ok=True)
+
+        if not self._token_path.exists():
+            self._token_path.touch()
         return self._token_path
 
     @property
     def workspace_path(self):
         if self._workspace_path is None:
             self._workspace_path = self.root / "workspace"
-        self._workspace_path.touch(exist_ok=True)
+
+        if not self._workspace_path.exists():
+            self._workspace_path.touch()
         return self._workspace_path
 
     @property


### PR DESCRIPTION
Using `self._token_path.touch(exist_ok=True)` throws a `PermissionError` when the token file only has readonly permissions.

```python 
Unable to display contents of () - printing traceback:
/opt/miniconda/envs/jupyterlab/bin/latch:8 in <module>
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/click/core.py:1130 in __call__
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/click/core.py:1055 in main
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/click/core.py:1657 in invoke
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/click/core.py:1404 in invoke
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/click/core.py:760 in invoke
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/latch_cli/main.py:246 in ls
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/latch_cli/services/ls.py:34 in ls
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/latch_cli/utils.py:26 in retrieve_or_login
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/latch_cli/config/user.py:45 in token
/opt/miniconda/envs/jupyterlab/lib/python3.9/site-packages/latch_cli/config/user.py:28 in token_path
10 frames collapsed...

--Traceback (most recent call last)--
/opt/miniconda/envs/jupyterlab/lib/python3.9/pathlib.py:1315 in touch
  1313|         if not exist_ok:
  1314|             flags |= os.O_EXCL
> 1315|         fd = self._raw_open(flags, mode)
  1316|         os.close(fd)
  1317| 
  1318|     def mkdir(self, mode=0o777, parents=False, exist_ok=False):
  1319|         """

--Traceback (most recent call last)--
/opt/miniconda/envs/jupyterlab/lib/python3.9/pathlib.py:1127 in _raw_open
  1125|         as os.open() does.
  1126|         """
> 1127|         return self._accessor.open(self, flags, mode)
  1128| 
  1129|     # Public API
  1130| 
  1131|     @classmethod

PermissionError: [Errno 13] Permission denied: '/root/.latch/token'
```