### PR TITLE
fix: large file upload error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Types of changes
 
 # Latch SDK Changelog
 
+## 2.17.1 - 2023-04-07
+
+### Fixed
+
+- Prevent `latch cp` from hitting the s3 part limits which causes large 
+  file uploads to fail
+
 ## 2.17.1 - 2023-04-05
 
 ### Fixed

--- a/latch_cli/constants.py
+++ b/latch_cli/constants.py
@@ -16,6 +16,9 @@ class LatchConstants:
 
     file_chunk_size: int = 5 * mib
 
+    # https://repost.aws/knowledge-center/s3-upload-large-files
+    maximum_upload_parts = 10000
+
     pkg_name: str = "latch"
     pkg_ssh_key: str = ".latch/ssh_key"
     pkg_config: str = ".latch/config"
@@ -31,7 +34,6 @@ latch_constants = LatchConstants()
 
 @dataclass(frozen=True)
 class OAuth2Constants:
-
     client_id: str = "jzFBOhIbfp4EPRYZ8wmx4YyvL27LFDeB"
     """Identifies the authentication server in 0Auth2.0 flow"""
 

--- a/latch_cli/constants.py
+++ b/latch_cli/constants.py
@@ -14,7 +14,7 @@ class LatchConstants:
 
     file_max_size: int = 4 * mib
 
-    file_chunk_size: int = 5 * mib
+    file_chunk_size: int = 256 * mib
 
     # https://repost.aws/knowledge-center/s3-upload-large-files
     maximum_upload_parts = 10000


### PR DESCRIPTION
s3 enforces a limit of 10k parts, which causes large multipart uploads to fail because our chunk size is too small