### PR TITLE
No `conda init` 

### DIFF
--- a/docs/source/basics/defining_environment.md
+++ b/docs/source/basics/defining_environment.md
@@ -102,8 +102,7 @@ run apt-get update --yes && \
     mkdir /root/.conda && \
     # docs for -b and -p flags: https://docs.anaconda.com/anaconda/install/silent-mode/#linux-macos
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
-    rm -f Miniconda3-latest-Linux-x86_64.sh && \
-    conda init bash
+    rm -f Miniconda3-latest-Linux-x86_64.sh
 
 copy environment.yaml /opt/latch/environment.yaml
 run conda env create --file /opt/latch/environment.yaml --name workflow

--- a/latch_cli/docker_utils/__init__.py
+++ b/latch_cli/docker_utils/__init__.py
@@ -116,10 +116,8 @@ def infer_commands(pkg_root: Path) -> List[DockerCmdBlock]:
                             mkdir /root/.conda && \
                             # docs for -b and -p flags: https://docs.anaconda.com/anaconda/install/silent-mode/#linux-macos
                             bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
-                            rm -f Miniconda3-latest-Linux-x86_64.sh && \
-                            conda init bash
-                        """
-                    ).strip(),
+                            rm -f Miniconda3-latest-Linux-x86_64.sh
+                        """).strip(),
                 ],
                 order=DockerCmdBlockOrder.precopy,
             ),


### PR DESCRIPTION
`conda init` prefixes `PATH` with `/opt/conda/bin:/opt/conda/condabin`. We want the first directory in path to be the environment defined in the environment.yaml file instead