### PR TITLE
Kenny/python ssh

### DIFF
--- a/latch_cli/centromere/ctx.py
+++ b/latch_cli/centromere/ctx.py
@@ -31,8 +31,6 @@ from latch_cli.utils import (
     retrieve_or_login,
 )
 
-ssh_config_expr = re.compile(r"^# >>> LATCH$.*^# LATCH <<<$", re.MULTILINE | re.DOTALL)
-
 
 @dataclass
 class _Container:

--- a/latch_cli/centromere/utils.py
+++ b/latch_cli/centromere/utils.py
@@ -233,7 +233,7 @@ class MaybeRemoteDir:
             self._tempdir = tempfile.TemporaryDirectory()
             return Path(self._tempdir.name).resolve()
 
-        td = build_random_dir_name()
+        td = build_random_string()
 
         self._tempdir = f"/tmp/{td}"
 
@@ -248,9 +248,9 @@ class MaybeRemoteDir:
             self._tempdir.cleanup()
 
 
-def build_random_dir_name() -> str:
+def build_random_string(k: int = 8) -> str:
     return "".join(
         random.choices(
-            string.ascii_uppercase + string.ascii_lowercase + string.digits, k=8
+            string.ascii_uppercase + string.ascii_lowercase + string.digits, k=k
         )
     )

--- a/latch_cli/centromere/utils.py
+++ b/latch_cli/centromere/utils.py
@@ -5,6 +5,7 @@ import random
 import string
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Iterator, List, Optional
@@ -16,6 +17,14 @@ from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.tools import module_loader
 
 from latch_cli.constants import latch_constants
+
+
+@dataclass
+class RemoteConnInfo:
+    ip: str
+    username: str
+    jump_key_path: Path
+    ssh_key_path: Path
 
 
 @contextlib.contextmanager
@@ -146,7 +155,7 @@ def _construct_dkr_client(ssh_host: Optional[str] = None):
 
     if ssh_host is not None:
         try:
-            return docker.APIClient(ssh_host, use_ssh_client=True)
+            return docker.APIClient(ssh_host, version="1.41")
         except docker.errors.DockerException as de:
             raise OSError(
                 f"Unable to establish a connection to remote docker host {ssh_host}."
@@ -167,45 +176,51 @@ def _construct_dkr_client(ssh_host: Optional[str] = None):
             ) from de
 
 
-def _construct_ssh_client(internal_ip: str, username: str) -> paramiko.SSHClient:
+def _construct_ssh_client(remote_conn_info: RemoteConnInfo) -> paramiko.SSHClient:
     gateway = paramiko.SSHClient()
     gateway.load_system_host_keys()
     gateway.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy)
-    gateway.connect(latch_constants.jump_host, username=latch_constants.jump_user)
+    gateway.connect(
+        latch_constants.jump_host,
+        username=latch_constants.jump_user,
+        key_filename=str(remote_conn_info.jump_key_path.resolve()),
+    )
 
-    transport = gateway.get_transport()
-    if transport is None:
+    gateway_transport = gateway.get_transport()
+    if gateway_transport is None:
         raise ConnectionError("unable to create connection to jump host")
-    sock = transport.open_channel(
+    sock = gateway_transport.open_channel(
         kind="direct-tcpip",
-        dest_addr=(internal_ip, 22),
+        dest_addr=(remote_conn_info.ip, 22),
         src_addr=("", 0),
     )
 
     ssh = paramiko.SSHClient()
     ssh.load_system_host_keys()
     ssh.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy)
-    ssh.connect(internal_ip, username=username, sock=sock)
+    ssh.connect(
+        remote_conn_info.ip,
+        username=remote_conn_info.username,
+        sock=sock,
+        key_filename=str(remote_conn_info.ssh_key_path.resolve()),
+    )
+    transport = ssh.get_transport()
+    if transport is None:
+        raise ConnectionError(
+            "unable to create connection from jump host to centromere deployment"
+        )
+    # (kenny) Equivalent of OpenSSH configuration `ServerAliveInterval`
+    # No analogue for `ServerAliveCountMax` in paramiko I could find.
+    transport.set_keepalive(latch_constants.centromere_keepalive_interval)
     return ssh
 
 
-class _TmpDir:
+class MaybeRemoteDir:
 
-    """Represents a temporary directory that can be local or on a remote machine."""
+    """A temporary directory that exists locally or on a remote machine."""
 
-    def __init__(
-        self,
-        remote=False,
-        internal_ip: Optional[str] = None,
-        username: Optional[str] = None,
-    ):
-        if remote and (internal_ip is None or username is None):
-            raise ValueError("Must provide an ssh connection if remote is True.")
-
-        self.remote = remote
-        self.internal_ip = internal_ip
-        self.username = username
-        self._tempdir = None
+    def __init__(self, ssh_client: Optional[paramiko.SSHClient] = None):
+        self.ssh_client = ssh_client
 
     def __enter__(self, *args):
         return self.create(*args)
@@ -214,32 +229,28 @@ class _TmpDir:
         self.cleanup(*args)
 
     def create(self, *args):
-        if not self.remote:
+        if self.ssh_client is None:
             self._tempdir = tempfile.TemporaryDirectory()
             return Path(self._tempdir.name).resolve()
 
-        if self.internal_ip is None or self.username is None:
-            raise ValueError("Must provide an ssh connection if remote is True.")
-
-        td = "".join(
-            random.choices(
-                string.ascii_uppercase + string.ascii_lowercase + string.digits, k=8
-            )
-        )
+        td = build_random_dir_name()
 
         self._tempdir = f"/tmp/{td}"
 
-        client = _construct_ssh_client(self.internal_ip, self.username)
-        client.exec_command(f"mkdir {self._tempdir}")
+        self.ssh_client.exec_command(f"mkdir {self._tempdir}")
         return self._tempdir
 
     def cleanup(self, *args):
-        if (
-            not self.remote
-            and self._tempdir is not None
-            and not isinstance(self._tempdir, str)
-        ):
+        if self.ssh_client is not None:
+            self.ssh_client.exec_command(f"rm -rf {self._tempdir}")
+            return
+        if self._tempdir is not None and not isinstance(self._tempdir, str):
             self._tempdir.cleanup()
-        elif not (self.internal_ip is None or self.username is None):
-            client = _construct_ssh_client(self.internal_ip, self.username)
-            client.exec_command(f"rm -rf {self._tempdir}")
+
+
+def build_random_dir_name() -> str:
+    return "".join(
+        random.choices(
+            string.ascii_uppercase + string.ascii_lowercase + string.digits, k=8
+        )
+    )

--- a/latch_cli/constants.py
+++ b/latch_cli/constants.py
@@ -45,11 +45,12 @@ class LatchConstants:
         r"(\.git|\.latch_report\.tar\.gz|traceback\.txt|metadata\.json)$"
     )
 
-    # todo(ayush): add a dns record so this isn't hot garbage
-    jump_host = (
-        "a379501a3e5e54a2c8d1cc4f7ed32630-1582965659.us-west-2.elb.amazonaws.com"
-    )
-    jump_user = "jumpuser"
+    jump_host: str = "jump.centromere.latch.bio"
+    jump_user: str = "jumpuser"
+
+    # seconds
+    centromere_poll_timeout: int = 18000
+    centromere_keepalive_interval: int = 30
 
 
 latch_constants = LatchConstants()

--- a/latch_cli/services/register/register.py
+++ b/latch_cli/services/register/register.py
@@ -12,7 +12,7 @@ import click
 from scp import SCPClient
 
 from latch_cli.centromere.ctx import _CentromereCtx
-from latch_cli.centromere.utils import _construct_ssh_client, _TmpDir
+from latch_cli.centromere.utils import MaybeRemoteDir, _construct_ssh_client
 from latch_cli.services.register.constants import ANSI_REGEX, MAX_LINES
 from latch_cli.services.register.utils import (
     _build_image,
@@ -285,13 +285,7 @@ def register(
             print("Connecting to remote server for docker build...")
 
         with contextlib.ExitStack() as stack:
-            td = stack.enter_context(
-                _TmpDir(
-                    remote=remote,
-                    internal_ip=ctx.internal_ip,
-                    username=ctx.username,
-                )
-            )
+            td = stack.enter_context(MaybeRemoteDir(ctx.ssh_client))
             _build_and_serialize(
                 ctx,
                 ctx.default_container.image_name,
@@ -310,13 +304,7 @@ def register(
                 protos = _recursive_list(td)
 
             for task_name, container in ctx.container_map.items():
-                task_td = stack.enter_context(
-                    _TmpDir(
-                        remote=remote,
-                        internal_ip=ctx.internal_ip,
-                        username=ctx.username,
-                    )
-                )
+                task_td = stack.enter_context(MaybeRemoteDir(ctx.ssh_client))
                 try:
                     _build_and_serialize(
                         ctx,

--- a/latch_cli/services/register/register.py
+++ b/latch_cli/services/register/register.py
@@ -296,8 +296,9 @@ def register(
             protos = _recursive_list(td)
             if remote:
                 local_td = stack.enter_context(tempfile.TemporaryDirectory())
-                ssh = _construct_ssh_client(ctx.internal_ip, ctx.username)
-                scp = SCPClient(transport=ssh.get_transport(), sanitize=lambda x: x)
+                scp = SCPClient(
+                    transport=ctx.ssh_client.get_transport(), sanitize=lambda x: x
+                )
                 scp.get(f"{td}/*", local_path=local_td, recursive=True)
                 protos = _recursive_list(local_td)
             else:
@@ -317,9 +318,8 @@ def register(
 
                     if remote:
                         local_td = stack.enter_context(tempfile.TemporaryDirectory())
-                        ssh = _construct_ssh_client(ctx.internal_ip, ctx.username)
                         scp = SCPClient(
-                            transport=ssh.get_transport(),
+                            transport=ctx.ssh_client.get_transport(),
                             sanitize=lambda x: x,
                         )
                         scp.get(f"{task_td}/*", local_path=local_td, recursive=True)


### PR DESCRIPTION
`register` now uses pure python implementation of ssh (paramiko) for both the docker and centromere connection. no more interaction with `ssh-agent` or global ssh config file