### PR TITLE
Kenny/small sm fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Types of changes
 
 # Latch SDK Changelog
 
+## 2.32.5 - 2023-08-28
+
+### Fixed
+
+* Snakemake:
+    * Ignore global ruleorder directive
+    * Ignore temporary condition on output values
+
 ## 2.32.4 - 2023-08-28
 
 ### Fixed

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -15,6 +15,7 @@ from snakemake.parser import (
     Params,
     Python,
     Rule,
+    Ruleorder,
     Shell,
 )
 from snakemake.rules import Rule as RRule
@@ -183,6 +184,8 @@ Output.block_content = skipping_block_content
 Params.block_content = skipping_block_content
 Benchmark.block_content = skipping_block_content
 Log.block_content = skipping_block_content
+# TODO (kenny) - enforce rule order instead of ignoring it
+Ruleorder.block_content = skipping_block_content
 
 
 class SkippingRule(Rule):

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -109,6 +109,10 @@ def render_annotated_str(x) -> str:
         res = f"directory({res})"
         del flags["directory"]
 
+    # TODO (kenny) ~ handle temporary values
+    if "temp" in flags:
+        del flags["temp"]
+
     if len(flags) != 0:
         raise RuntimeError(f"found unsupported flags: {repr(flags)}")
 

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -166,7 +166,7 @@ emitted_overrides_per_type: Dict[str, Set[str]] = {}
 
 
 def skipping_block_content(self, token):
-    if self.rulename not in rules:
+    if type(self) in (Ruleorder) or self.rulename not in rules:
         return
 
     emitted_overrides = emitted_overrides_per_type.setdefault(

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -166,7 +166,7 @@ emitted_overrides_per_type: Dict[str, Set[str]] = {}
 
 
 def skipping_block_content(self, token):
-    if type(self) == Ruleorder or self.rulename not in rules:
+    if self.rulename not in rules:
         return
 
     emitted_overrides = emitted_overrides_per_type.setdefault(
@@ -184,8 +184,8 @@ Output.block_content = skipping_block_content
 Params.block_content = skipping_block_content
 Benchmark.block_content = skipping_block_content
 Log.block_content = skipping_block_content
-# TODO (kenny) - enforce rule order instead of ignoring it
-Ruleorder.block_content = skipping_block_content
+# todo(kenny): enforce rule order instead of ignoring it
+Ruleorder.block_content = lambda self, token: None
 
 
 class SkippingRule(Rule):

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -166,7 +166,7 @@ emitted_overrides_per_type: Dict[str, Set[str]] = {}
 
 
 def skipping_block_content(self, token):
-    if type(self) in (Ruleorder) or self.rulename not in rules:
+    if type(self) == Ruleorder or self.rulename not in rules:
         return
 
     emitted_overrides = emitted_overrides_per_type.setdefault(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if cur_ver < (3, 8) or cur_ver > (3, 11):
 
 setup(
     name="latch",
-    version="v2.32.4",
+    version="v2.32.5",
     author_email="kenny@latch.bio",
     description="The Latch SDK",
     packages=find_packages(),


### PR DESCRIPTION
* Ignore temporary output value. Handle as normal value + ignore temporary condition

```
rule foo:
    output:
        bam = temp("{sample}.unmapped.bam")
```

* Ignore global `ruleorder`. Currently crashes if present in snakefile, - allow workflow to run as normal and avoid 

```
ruleorder: call_consensus_reads > fastq_to_ubam
```