### PR TITLE
More snakemake fixes

### DIFF
--- a/latch_cli/docker_utils/__init__.py
+++ b/latch_cli/docker_utils/__init__.py
@@ -32,7 +32,13 @@ class DockerCmdBlock:
         f.write("\n".join(self.commands) + "\n\n")
 
 
-def get_prologue(config: LatchWorkflowConfig) -> List[str]:
+def get_prologue(
+    config: LatchWorkflowConfig, wf_type: WorkflowType = WorkflowType.latchbiosdk
+) -> List[str]:
+    if wf_type == WorkflowType.snakemake:
+        library_name = '"latch[snakemake]"'
+    else:
+        library_name = "latch"
     return [
         "# DO NOT CHANGE",
         f"from {config.base_image}",
@@ -59,7 +65,7 @@ def get_prologue(config: LatchWorkflowConfig) -> List[str]:
         "",
         "# Latch SDK",
         "# DO NOT REMOVE",
-        f"run pip install latch=={config.latch_version}",
+        f"run pip install {library_name}=={config.latch_version}",
         "run mkdir /opt/latch",
     ]
 
@@ -361,7 +367,7 @@ def generate_dockerfile(
     click.echo()
 
     with outfile.open("w") as f:
-        f.write("\n".join(get_prologue(config)) + "\n\n")
+        f.write("\n".join(get_prologue(config, wf_type)) + "\n\n")
 
         commands = infer_commands(pkg_root)
         if len(commands) > 0:

--- a/latch_cli/snakemake/serialize.py
+++ b/latch_cli/snakemake/serialize.py
@@ -120,6 +120,8 @@ class SnakemakeWorkflowExtractor(Workflow):
             self.rules,
             targetfiles=target_files,
             targetrules=target_rules,
+            priorityrules=set(),
+            priorityfiles=set(),
         )
 
         self.persistence = Persistence(

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -56,7 +56,7 @@ for rule in rules:
     eprint_named_list(rule_data["outputs"])
 
     eprint("    Params:")
-    eprint_named_list(rule_data["params"])
+    e(rule_data["params"])
 
     eprint("    Benchmark:")
     eprint(f"      {rule_data['benchmark']}")

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -106,16 +106,25 @@ def render_annotated_str(x) -> str:
     flags = dict(x["flags"])
 
     res = repr(value)
-    if flags.get("directory", False):
+
+    if len(flags) > 1:
+        raise RuntimeError(f"can only have one flag for {res} but found: {repr(flags)}")
+
+    if "directory" in flags:
         res = f"directory({res})"
-        del flags["directory"]
 
-    # TODO (kenny) ~ handle temporary values
-    if "temp" in flags:
+    elif "report" in flags:
+        report_vals = flags.get("report", False)
+        res = (
+            f"report({res}, caption={report_vals['caption']},"
+            f" category={report_vals['category']})"
+        )
+
+    elif "temp" in flags:
+        # A temporary modifier is no different from a normal file as all files
+        # are deleted on Latch after a job completes.
+        # https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#protected-and-temporary-files
         del flags["temp"]
-
-    if len(flags) != 0:
-        raise RuntimeError(f"found unsupported flags: {repr(flags)}")
 
     return res
 
@@ -184,7 +193,6 @@ Output.block_content = skipping_block_content
 Params.block_content = skipping_block_content
 Benchmark.block_content = skipping_block_content
 Log.block_content = skipping_block_content
-# todo(kenny): enforce rule order instead of ignoring it
 Ruleorder.block_content = lambda self, token: None
 
 

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -116,7 +116,7 @@ def render_annotated_str(x) -> str:
     elif "report" in flags:
         report_vals = flags.get("report", False)
         res = (
-            f"report({res}, caption={report_vals['caption']},"
+            f"report({res}, caption={repr(report_vals['caption'])},"
             f" category={report_vals['category']})"
         )
 

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -56,7 +56,7 @@ for rule in rules:
     eprint_named_list(rule_data["outputs"])
 
     eprint("    Params:")
-    e(rule_data["params"])
+    eprint_named_list(rule_data["params"])
 
     eprint("    Benchmark:")
     eprint(f"      {rule_data['benchmark']}")

--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -1215,7 +1215,10 @@ class SnakemakeJobTask(PythonAutoContainerTask[Pod]):
             snakemake_data["rules"][job.rule.name] = {
                 "inputs": named_list_to_json(job.input),
                 "outputs": named_list_to_json(job.output),
-                "params": json.dumps(job.params),
+                "params": {
+                    "keyword": {k: v for k, v in job.params.items()},
+                    "positional": [],
+                },
                 "benchmark": job.benchmark,
                 "log": job.log,
                 "shellcmd": job.shellcmd,
@@ -1227,8 +1230,6 @@ class SnakemakeJobTask(PythonAutoContainerTask[Pod]):
             remote_path = Path(urlparse(remote_output_url).path)
 
         log_files = self.job.log if self.job.log is not None else []
-
-        print(f"\n\nSnakemake data to be serialized:\n{snakemake_data}")
 
         code_block += reindent(
             rf"""

--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -2,10 +2,20 @@ import importlib
 import json
 import textwrap
 import typing
-from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 from urllib.parse import urlparse
 
 import snakemake

--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -392,7 +392,6 @@ class JITRegisterWorkflow(WorkflowBase, ClassStorageTaskResolver):
         code_block += reindent(
             rf"""
             image_name = "{image_name}"
-            image_base_name = image_name.split(":")[0]
             account_id = "{account_id}"
             snakefile = Path("{snakefile_path}")
 
@@ -409,6 +408,8 @@ class JITRegisterWorkflow(WorkflowBase, ClassStorageTaskResolver):
             exec_id_hash.update(os.environ["FLYTE_INTERNAL_EXECUTION_ID"].encode("utf-8"))
             version = exec_id_hash.hexdigest()[:16]
 
+            import time
+            time.sleep(1000000)
             wf = extract_snakemake_workflow(pkg_root, snakefile, version)
             wf_name = wf.name
             generate_snakemake_entrypoint(wf, pkg_root, snakefile, {repr(remote_output_url)})

--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -1221,6 +1221,8 @@ class SnakemakeJobTask(PythonAutoContainerTask[Pod]):
 
         log_files = self.job.log if self.job.log is not None else []
 
+        print(f"\n\nSnakemake data to be serialized:\n{snakemake_data}")
+
         code_block += reindent(
             rf"""
             lp = LatchPersistence()


### PR DESCRIPTION
## `Iterable`, `Generator` cause issues as type hints when imported from `collections.abc` rather than `typing`

## Generate Dockerfile that installs snakemake extras when in snakemake project

## Add empty priority rules to avoid iterating over None

## Support for parameter flags

    * `temp`
    * `report`

Serialize sufficient fields to reconstruct tuples when parsing for each
task. The following an example for `report`.

```
@workflow.output(
    report (
    "results/qc/multiqc.html" ,
    caption = "../report/multiqc.rst" ,
    category = "Quality control" ,
    ) ,

)
```

## Support for arbitrary parameter values (like dicts)