### PR TITLE
Remove docker build from snakemake JIT 

### DIFF
--- a/latch/resources/tasks.py
+++ b/latch/resources/tasks.py
@@ -323,8 +323,8 @@ def custom_memory_optimized_task(cpu: int, memory: int):
         memory: An integer number of Gibibytes of RAM to request, up to 511 GiB
     """
     warn(
-        "`custom_memory_optimized_task` is deprecated and will be removed in a future"
-        " release: use `custom_task` instead",
+        "`custom_memory_optimized_task` is deprecated and will be removed in a"
+        " future release: use `custom_task` instead",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/latch_cli/services/register/register.py
+++ b/latch_cli/services/register/register.py
@@ -488,10 +488,6 @@ def register(
             retries = 0
 
             wf_name = ctx.workflow_name
-            if snakefile is not None:
-                # todo(maximsmol): this is quite awful
-                wf_name = f"{wf_name}_jit_register"
-
             while len(wf_infos) == 0:
                 wf_infos = l_gql.execute(
                     gql.gql("""

--- a/latch_cli/snakemake/config/parser.py
+++ b/latch_cli/snakemake/config/parser.py
@@ -126,8 +126,9 @@ def generate_metadata(
             old_metadata_path.rename(metadata_path)
     elif old_metadata_path.exists() and metadata_path.exists():
         click.secho(
-            "Warning: Found both `latch_metadata.py` and `latch_metadata/__init__.py`"
-            " in current directory. `latch_metadata.py` will be ignored.",
+            "Warning: Found both `latch_metadata.py` and"
+            " `latch_metadata/__init__.py` in current directory."
+            " `latch_metadata.py` will be ignored.",
             fg="yellow",
         )
 

--- a/latch_cli/snakemake/serialize.py
+++ b/latch_cli/snakemake/serialize.py
@@ -169,7 +169,7 @@ class SnakemakeWorkflowExtractor(Workflow):
 
 
 def snakemake_workflow_extractor(
-    pkg_root: Path, snakefile: Path, version: Optional[str] = None
+    pkg_root: Path, snakefile: Path
 ) -> SnakemakeWorkflowExtractor:
     snakefile = snakefile.resolve()
 
@@ -198,13 +198,16 @@ def snakemake_workflow_extractor(
 def extract_snakemake_workflow(
     pkg_root: Path,
     snakefile: Path,
-    version: Optional[str] = None,
+    jit_wf_version: str,
+    jit_exec_display_name: str,
     local_to_remote_path_mapping: Optional[Dict[str, str]] = None,
 ) -> SnakemakeWorkflow:
-    extractor = snakemake_workflow_extractor(pkg_root, snakefile, version)
+    extractor = snakemake_workflow_extractor(pkg_root, snakefile)
     with extractor:
         dag = extractor.extract_dag()
-        wf = SnakemakeWorkflow(dag, version, local_to_remote_path_mapping)
+        wf = SnakemakeWorkflow(
+            dag, jit_wf_version, jit_exec_display_name, local_to_remote_path_mapping
+        )
         wf.compile()
 
     return wf

--- a/latch_cli/snakemake/serialize.py
+++ b/latch_cli/snakemake/serialize.py
@@ -489,6 +489,6 @@ def generate_jit_register_code(
 
     entrypoint = pkg_root / ".latch" / "snakemake_jit_entrypoint.py"
     entrypoint.parent.mkdir(parents=True, exist_ok=True)
-    # entrypoint.write_text(code_block + "\n")
+    entrypoint.write_text(code_block + "\n")
 
     return entrypoint

--- a/latch_cli/snakemake/serialize.py
+++ b/latch_cli/snakemake/serialize.py
@@ -489,6 +489,6 @@ def generate_jit_register_code(
 
     entrypoint = pkg_root / ".latch" / "snakemake_jit_entrypoint.py"
     entrypoint.parent.mkdir(parents=True, exist_ok=True)
-    entrypoint.write_text(code_block + "\n")
+    # entrypoint.write_text(code_block + "\n")
 
     return entrypoint

--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -101,8 +101,7 @@ class JobOutputInfo:
     type_: Union[Type[LatchFile], Type[LatchDir]]
 
 
-def task_fn_placeholder():
-    ...
+def task_fn_placeholder(): ...
 
 
 def variable_name_for_file(file: snakemake.io.AnnotatedString):

--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -101,7 +101,8 @@ class JobOutputInfo:
     type_: Union[Type[LatchFile], Type[LatchDir]]
 
 
-def task_fn_placeholder(): ...
+def task_fn_placeholder():
+    ...
 
 
 def variable_name_for_file(file: snakemake.io.AnnotatedString):
@@ -1090,6 +1091,22 @@ class SnakemakeJobTask(PythonAutoContainerTask[Pod]):
             final_containers.append(container)
 
         self.task_config._pod_spec.containers = final_containers
+
+        self.task_config._pod_spec.init_containers = [
+            V1Container(
+                command=[
+                    "latch",
+                    "cp",
+                    "latch://1.account/foo.txt",
+                    "/opt/latch/latch_entrypoint.py",
+                ],
+                image="x1_snakemake_snakemake_tutorial_workflow:0.0.0-75c0bf",
+                resources=V1ResourceRequirements(
+                    requests={"memory": "1Gi", "cpu": "1"},
+                ),
+                name="foo",
+            )
+        ]
 
         return ApiClient().sanitize_for_serialization(self.task_config.pod_spec)
 

--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -475,7 +475,7 @@ class JITRegisterWorkflow(WorkflowBase, ClassStorageTaskResolver):
             wf_name = wf.name
             generate_snakemake_entrypoint(wf, pkg_root, snakefile, {repr(remote_output_url)}, non_blob_parameters)
 
-            entrypoint_remote = f"latch:///.snakemake_latch/workflows/{{wf_name}}/entrypoint.py"
+            entrypoint_remote = f"latch:///.snakemake_latch/workflows/{{wf_name}}/{{version}}/entrypoint.py"
             lp.upload("latch_entrypoint.py", entrypoint_remote)
             print(f"latch_entrypoint.py -> {{entrypoint_remote}}")
             """,
@@ -497,7 +497,7 @@ class JITRegisterWorkflow(WorkflowBase, ClassStorageTaskResolver):
                 reg_resp = register_serialized_pkg(protos, None, version, account_id)
                 # _print_reg_resp(reg_resp, new_image_name, silent=True)
 
-            wf_spec_remote = f"latch:///.snakemake_latch/workflows/{wf_name}/spec"
+            wf_spec_remote = f"latch:///.snakemake_latch/workflows/{wf_name}/{version}/spec"
             spec_dir = Path("spec")
             for x_dir in spec_dir.iterdir():
                 if not x_dir.is_dir():
@@ -582,6 +582,7 @@ class SnakemakeWorkflow(WorkflowBase, ClassStorageTaskResolver):
     ):
         assert metadata._snakemake_metadata is not None
         name = metadata._snakemake_metadata.name
+        self.version = version
 
         assert name is not None
 
@@ -968,7 +969,7 @@ class SnakemakeJobTask(PythonAutoContainerTask[Pod]):
                     "-c",
                     (
                         "exec 3>&1 4>&2 && latch cp"
-                        f" latch:///.snakemake_latch/workflows/{self.wf.name}/entrypoint.py"
+                        f" latch:///.snakemake_latch/workflows/{self.wf.name}/{self.wf.version}/entrypoint.py"
                         " /opt/latch/latch_entrypoint.py && ("
                         f" {' '.join(sdk_default_container.args)} 1>&3 2>&4 )"
                     ),

--- a/latch_cli/utils/__init__.py
+++ b/latch_cli/utils/__init__.py
@@ -220,8 +220,8 @@ def hash_directory(dir_path: Path) -> str:
         file_size = p_stat.st_size
         if not stat.S_ISREG(p_stat.st_mode):
             click.secho(
-                f"{p.relative_to(dir_path.resolve())} is not a regular file. Ignoring"
-                " contents",
+                f"{p.relative_to(dir_path.resolve())} is not a regular file."
+                " Ignoring contents",
                 fg="yellow",
                 bold=True,
             )


### PR DESCRIPTION
This shaves ~10 seconds from JIT.

Purpose of docker build in the JIT step was to add the latch-entrypoint file to the container of each job task.

We remove this and each job task now fetches the entrypoint before executing pyflyte code.

```
    Command:
      /bin/bash
      -c
      exec 3>&1 4>&2 && latch cp latch:///.snakemake_latch/workflows/snakemake_test_init/entrypoint.py /opt/latch/latch_entrypoint.py && ( pyflyte-execute --inputs s3://prion-flyte-prod/metadata/propeller/1-development-fd1bf39e849e44f98874/n4/data/inputs.pb --output-prefix s3://prion-flyte-prod/metadata/propeller/1-development-fd1bf39e849e44f98874/n4/data/0 --raw-output-data-prefix s3://prion-flyte-prod/q9/fd1bf39e849e44f98874-n4-0 --checkpoint-path s3://prion-flyte-prod/q9/fd1bf39e849e44f98874-n4-0/_flytecheckpoints --prev-checkpoint "" --resolver flytekit.core.python_auto_container.default_task_resolver -- task-module latch_entrypoint task-name bwa_map_4 1>&3 2>&4 )
```

We ditched implementation as an init container because:
- Init containers do not have environment variables needed to authenticate `latch cp` and require propeller plugin modification
- Would double the containers scheduled and could cause performance issues with batched workflows of many tasks