### PR TITLE
Add italic and underline to selection menus

### DIFF
--- a/latch_cli/menus.py
+++ b/latch_cli/menus.py
@@ -228,8 +228,10 @@ def select_tui(title: str, options: List[str], clear_terminal: bool = True):
             if i == curr_selected:
                 color = "\x1b[38;5;40m"
                 bold = "\x1b[1m"
+                italic = "\x1b[3m"
+                underline = "\x1b[4m"
                 reset = "\x1b[0m"
-                _print(f"{indent}{color}{bold}{name}{reset}\x1b[1E")
+                _print(f"{indent}{color}{bold}{italic}{underline}{name}{reset}\x1b[1E")
             else:
                 _print(f"{indent}{name}\x1b[1E")
             num_lines_rendered += 1


### PR DESCRIPTION
I have a tough time _just_ seeing the bold highlighted text with the fonts I use, so would welcome either italic or underline (or both!).  This is an issue when selecting workspaces.