### PR TITLE
Use code-block for online docs in metadata.py

### DIFF
--- a/latch/types/metadata.py
+++ b/latch/types/metadata.py
@@ -103,73 +103,72 @@ class Section(FlowBase):
 
     The `LatchMedata` for the example above can be defined as follows:
 
-    ```python
-    from latch.types import LatchMetadata, LatchParameter
-    from latch.types.metadata import FlowBase, Section, Text, Params, Fork, Spoiler
-    from latch import workflow
-
-    flow = [
-        Section(
-            "Samples",
-            Text(
-                "Sample provided has to include an identifier for the sample (Sample name)"
-                " and one or two files corresponding to the reads (single-end or paired-end, respectively)"
+    .. code-block: python
+        from latch.types import LatchMetadata, LatchParameter
+        from latch.types.metadata import FlowBase, Section, Text, Params, Fork, Spoiler
+        from latch import workflow
+        
+        flow = [
+            Section(
+                "Samples",
+                Text(
+                    "Sample provided has to include an identifier for the sample (Sample name)"
+                    " and one or two files corresponding to the reads (single-end or paired-end, respectively)"
+                ),
+                Fork(
+                    "sample_fork",
+                    "Choose read type",
+                    paired_end=ForkBranch("Paired-end", Params("paired_end")),
+                    single_end=ForkBranch("Single-end", Params("single_end")),
+                ),
             ),
-            Fork(
-                "sample_fork",
-                "Choose read type",
-                paired_end=ForkBranch("Paired-end", Params("paired_end")),
-                single_end=ForkBranch("Single-end", Params("single_end")),
+            Section(
+                "Quality threshold",
+                Text(
+                    "Select the quality value in which a base is qualified."
+                    "Quality value refers to a Phred quality score"
+                ),
+                Params("quality_threshold"),
             ),
-        ),
-        Section(
-            "Quality threshold",
-            Text(
-                "Select the quality value in which a base is qualified."
-                "Quality value refers to a Phred quality score"
+            Spoiler(
+                "Output directory",
+                Text("Name of the output directory to send results to."),
+                Params("output_directory"),
             ),
-            Params("quality_threshold"),
-        ),
-        Spoiler(
-            "Output directory",
-            Text("Name of the output directory to send results to."),
-            Params("output_directory"),
-        ),
-    ]
-
-    metadata = LatchMetadata(
-        display_name="fastp - Flow Tutorial",
-        author=LatchAuthor(
-            name="LatchBio",
-        ),
-        parameters={
-            "sample_fork": LatchParameter(),
-            "paired_end": LatchParameter(
-                display_name="Paired-end reads",
-                description="FASTQ files",
-                batch_table_column=True,
+        ]
+    
+        metadata = LatchMetadata(
+            display_name="fastp - Flow Tutorial",
+            author=LatchAuthor(
+                name="LatchBio",
             ),
-            "single_end": LatchParameter(
-                display_name="Single-end reads",
-                description="FASTQ files",
-                batch_table_column=True,
-            ),
-            "output_directory": LatchParameter(
-                display_name="Output directory",
-            ),
-        },
-        flow=flow,
-    )
-
-    @workflow(metadata)
-    def fastp(
-        sample_fork: str,
-        paired_end: PairedEnd,
-        single_end: Optional[SingleEnd] = None,
-        output_directory: str = "fastp_results",
-    ) -> LatchDir:
+            parameters={
+                "sample_fork": LatchParameter(),
+                "paired_end": LatchParameter(
+                    display_name="Paired-end reads",
+                    description="FASTQ files",
+                    batch_table_column=True,
+                ),
+                "single_end": LatchParameter(
+                    display_name="Single-end reads",
+                    description="FASTQ files",
+                    batch_table_column=True,
+                ),
+                "output_directory": LatchParameter(
+                    display_name="Output directory",
+                ),
+            },
+            flow=flow,
+        )
+    
+        @workflow(metadata)
+        def fastp(
+            sample_fork: str,
+            paired_end: PairedEnd,
+            single_end: Optional[SingleEnd] = None,
+            output_directory: str = "fastp_results",
+        ) -> LatchDir:
         ...
-    ```
     """
 
     section: str
@@ -420,45 +419,44 @@ class LatchMetadata:
 
     Example:
 
-    ```python
-    from latch.types import LatchMetadata, LatchAuthor, LatchRule, LatchAppearanceType
-
-    metadata = LatchMetadata(
-        parameters={
-            "read1": LatchParameter(
-                display_name="Read 1",
-                description="Paired-end read 1 file to be assembled.",
-                hidden=True,
-                section_title="Sample Reads",
-                placeholder="Select a file",
-                comment="This is a comment",
-                output=False,
-                appearance_type=LatchAppearanceType.paragraph,
-                rules=[
-                    LatchRule(
-                        regex="(.fasta|.fa|.faa|.fas)$",
-                        message="Only .fasta, .fa, .fas, or .faa extensions are valid"
-                    )
-                ],
-                batch_table_column=True,  # Show this parameter in batched mode.
-                # The below parameters will be displayed on the side bar of the workflow
-                documentation="https://github.com/author/my_workflow/README.md",
-                author=LatchAuthor(
-                    name="Workflow Author",
-                    email="licensing@company.com",
-                    github="https://github.com/author",
+    .. code-block:: python
+        from latch.types import LatchMetadata, LatchAuthor, LatchRule, LatchAppearanceType
+        
+        metadata = LatchMetadata(
+            parameters={
+                "read1": LatchParameter(
+                    display_name="Read 1",
+                    description="Paired-end read 1 file to be assembled.",
+                    hidden=True,
+                    section_title="Sample Reads",
+                    placeholder="Select a file",
+                    comment="This is a comment",
+                    output=False,
+                    appearance_type=LatchAppearanceType.paragraph,
+                    rules=[
+                        LatchRule(
+                            regex="(.fasta|.fa|.faa|.fas)$",
+                            message="Only .fasta, .fa, .fas, or .faa extensions are valid"
+                        )
+                    ],
+                    batch_table_column=True,  # Show this parameter in batched mode.
+                    # The below parameters will be displayed on the side bar of the workflow
+                    documentation="https://github.com/author/my_workflow/README.md",
+                    author=LatchAuthor(
+                        name="Workflow Author",
+                        email="licensing@company.com",
+                        github="https://github.com/author",
+                    ),
+                    repository="https://github.com/author/my_workflow",
+                    license="MIT",
+                    # If the workflow is public, display it under the defined categories on Latch to be more easily discovered by users
+                    tags=["NGS", "MAG"],
                 ),
-                repository="https://github.com/author/my_workflow",
-                license="MIT",
-                # If the workflow is public, display it under the defined categories on Latch to be more easily discovered by users
-                tags=["NGS", "MAG"],
-            ),
-    )
-
-    @workflow(metadata)
-    def wf(read1: LatchFile):
-        ...
-    ```
+        )
+        
+        @workflow(metadata)
+        def wf(read1: LatchFile):
+            ...
     """
 
     display_name: str


### PR DESCRIPTION
Looking at the API docs online, it looks like some of the docs are in markdown versus restructured text:
![Screenshot 2023-11-10 at 9 47 40 PM](https://github.com/latchbio/latch/assets/846274/cc07f6a2-4b49-4506-b8f4-aba912446c1a)

It's probably a good idea to find these and update, as well as fixup some of the other issues: https://github.com/latchbio/latch/blob/7baa4791c2ac4998d8a27a48575eae04ef7b1b0d/latch/types/directory.py#L68C7-L69
