### PR TITLE
add import + better message for par

### DIFF
--- a/latch_cli/snakemake/config/parser.py
+++ b/latch_cli/snakemake/config/parser.py
@@ -126,11 +126,9 @@ def generate_metadata(
             old_metadata_path.rename(metadata_path)
     elif old_metadata_path.exists() and metadata_path.exists():
         click.secho(
-            (
-                "Warning: Found both `latch_metadata.py` and"
-                " `latch_metadata/__init__.py` in current directory."
-                " `latch_metadata.py` will be ignored."
-            ),
+            "Warning: Found both `latch_metadata.py` and"
+            " `latch_metadata/__init__.py` in current directory."
+            " `latch_metadata.py` will be ignored.",
             fg="yellow",
         )
 
@@ -187,9 +185,6 @@ def generate_metadata(
             # Import these into your `__init__.py` file:
             #
             # from .parameters import generated_parameters
-            #
-            # Use fully qualified names for types from typing (eg. typing.List,
-            # typing.Optional)
 
             generated_parameters = {
             __params__

--- a/latch_cli/snakemake/config/parser.py
+++ b/latch_cli/snakemake/config/parser.py
@@ -136,8 +136,8 @@ def generate_metadata(
 
     if not metadata_path.exists() and click.confirm(
         "Could not find an `__init__.py` file in `latch_metadata`. This file"
-        "will hold your metadata object the parameterizes your interface and"
-        "will use parameters imported from parameters.py"
+        "defines the metadata object that configures your interface and "
+        "uses parameters imported from `parameters.py`"
         "Generate one?"
     ):
         metadata_path.write_text(

--- a/latch_cli/snakemake/config/parser.py
+++ b/latch_cli/snakemake/config/parser.py
@@ -81,10 +81,16 @@ def generate_metadata(
 
         is_file = typ in {LatchFile, LatchDir}
         param_typ = "SnakemakeFileParameter" if is_file else "SnakemakeParameter"
+
+        def _best_effort_display_name(param_name: str):
+            if param_name[0] == "_":
+                param_name = param_name[1:]
+            return " ".join(map(lambda x: x.capitalize(), param_name.split("_")))
+
         param_str = reindent(
             f"""\
             {repr(identifier_from_str(k))}: {param_typ}(
-                display_name={repr(k)},
+                display_name={repr(_best_effort_display_name(k))},
                 type={type_repr(typ)},
             __config____default__),""",
             0,

--- a/latch_cli/snakemake/config/parser.py
+++ b/latch_cli/snakemake/config/parser.py
@@ -9,6 +9,7 @@ from latch.types.file import LatchFile
 from latch_cli.snakemake.workflow import reindent
 from latch_cli.utils import identifier_from_str
 
+from ..serialize_utils import best_effort_display_name
 from .utils import JSONValue, get_preamble, parse_type, parse_value, type_repr
 
 T = TypeVar("T")
@@ -82,15 +83,10 @@ def generate_metadata(
         is_file = typ in {LatchFile, LatchDir}
         param_typ = "SnakemakeFileParameter" if is_file else "SnakemakeParameter"
 
-        def _best_effort_display_name(param_name: str):
-            if param_name[0] == "_":
-                param_name = param_name[1:]
-            return " ".join(map(lambda x: x.capitalize(), param_name.split("_")))
-
         param_str = reindent(
             f"""\
             {repr(identifier_from_str(k))}: {param_typ}(
-                display_name={repr(_best_effort_display_name(k))},
+                display_name={repr(best_effort_display_name(k))},
                 type={type_repr(typ)},
             __config____default__),""",
             0,
@@ -132,9 +128,11 @@ def generate_metadata(
             old_metadata_path.rename(metadata_path)
     elif old_metadata_path.exists() and metadata_path.exists():
         click.secho(
-            "Warning: Found both `latch_metadata.py` and"
-            " `latch_metadata/__init__.py` in current directory."
-            " `latch_metadata.py` will be ignored.",
+            (
+                "Warning: Found both `latch_metadata.py` and"
+                " `latch_metadata/__init__.py` in current directory."
+                " `latch_metadata.py` will be ignored."
+            ),
             fg="yellow",
         )
 

--- a/latch_cli/snakemake/config/parser.py
+++ b/latch_cli/snakemake/config/parser.py
@@ -126,14 +126,19 @@ def generate_metadata(
             old_metadata_path.rename(metadata_path)
     elif old_metadata_path.exists() and metadata_path.exists():
         click.secho(
-            "Warning: Found both `latch_metadata.py` and"
-            " `latch_metadata/__init__.py` in current directory."
-            " `latch_metadata.py` will be ignored.",
+            (
+                "Warning: Found both `latch_metadata.py` and"
+                " `latch_metadata/__init__.py` in current directory."
+                " `latch_metadata.py` will be ignored."
+            ),
             fg="yellow",
         )
 
     if not metadata_path.exists() and click.confirm(
-        "Could not find an `__init__.py` file in `latch_metadata`. Generate one?"
+        "Could not find an `__init__.py` file in `latch_metadata`. This file"
+        "will hold your metadata object the parameterizes your interface and"
+        "will use parameters imported from parameters.py"
+        "Generate one?"
     ):
         metadata_path.write_text(
             reindent(
@@ -183,6 +188,9 @@ def generate_metadata(
             #
             # from .parameters import generated_parameters
             #
+            # Use fully qualified names for types from typing (eg. typing.List,
+            # typing.Optional)
+
             generated_parameters = {
             __params__
             }

--- a/latch_cli/snakemake/serialize.py
+++ b/latch_cli/snakemake/serialize.py
@@ -426,7 +426,8 @@ def generate_jit_register_code(
         from functools import partial
         from pathlib import Path
         import shutil
-        from typing import List, NamedTuple, Optional, TypedDict, Dict
+        import typing
+        from typing import NamedTuple, Optional, TypedDict, Dict
         import hashlib
         from urllib.parse import urljoin
         from dataclasses import is_dataclass, asdict

--- a/latch_cli/snakemake/serialize_utils.py
+++ b/latch_cli/snakemake/serialize_utils.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, Union
 
 from flytekit import LaunchPlan
@@ -210,3 +211,8 @@ def get_serializable_workflow(
     admin_wf = admin_workflow_models.WorkflowSpec(template=wf_t, sub_workflows=[])
     cache[entity] = admin_wf
     return admin_wf
+
+
+def best_effort_display_name(x: str):
+    expr = re.compile(r"_+")
+    return expr.sub(" ", x).title().strip()


### PR DESCRIPTION
Because parameter types in the jit workflow are now imported from the latch_metadata package they all use fully qualified names. If developer constructs their own types in that package we will have to figure out how to bring appropriate import statement to jit code in the future

