### PR TITLE
fix: prevent name collisions on input parameters

### DIFF
--- a/latch_cli/snakemake/workflow.py
+++ b/latch_cli/snakemake/workflow.py
@@ -190,12 +190,15 @@ def snakemake_dag_to_interface(
                 # as long as they are defined in different rules. This can lead to name collisions
                 # because we use a global mapping (across all rules) of param_name -> input_file.
                 if param in literals and literals[param].scalar.blob.uri != remote_url:
-                    click.secho(dedent(f"""
+                    click.secho(
+                        dedent(f"""
                         Name collision detected for {job.name}. The following two input
                         parameters have the same name but different remote paths:
                         {param} -> {remote_url}
                         {param} -> {literals[param].scalar.blob.uri}
-                        """))
+                        """),
+                        fg="red",
+                    )
                     sys.exit(1)
 
                 literals[param] = Literal(


### PR DESCRIPTION
In a Snakefile, it is possible for two different input files to have the same parameter name as long as they are defined in different rules. This can lead to name collisions because we use a global mapping (across all rules) of param_name -> input_file.

To avoid this name collision, I add a check and raise an error if it doesn't pass. 

I considered adding the job_id to the front of all the variable names, but I suspect that this will make the entrypoint file even less readable. Since this seems like enough of an edge case, I would prefer to just fail and raise an error rather than append the job id to all the variable names.