### PR TITLE
remove .latch dir copy from dockerfile generation

### DIFF
--- a/latch_cli/docker_utils/__init__.py
+++ b/latch_cli/docker_utils/__init__.py
@@ -379,9 +379,7 @@ def generate_dockerfile(
             block.write_block(f)
 
         f.write("# Copy workflow data (use .dockerignore to skip files)\n")
-
-        # this will only copy the snakemake entrypoint (if it exists) due to .dockerignore
-        f.write("copy . .latch/* /root/\n\n")
+        f.write("copy . /root/\n\n")
 
         for block in commands:
             if block.order != DockerCmdBlockOrder.postcopy:


### PR DESCRIPTION
Removing copy for .latch/* into /root in the Dockerfile generation. 

We are already explicitly copying the `snakemake_jit_entrypoint` file explicitly, so I don't think this is necessary. 

Also, I think we should make all copies from .latch explicit because we can potentially override user data which can be confusing for developer. For example, I was running into an issue where the .latch/config file was overriding the user's config directory which caused the JIT task to fail.