### PR TITLE
fix ruleorder directive 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Types of changes
 
 # Latch SDK Changelog
 
+## 2.38.8 - 2023-01-26
+
+### Fixed
+
+* Snakemake
+  + fix bug in `ruleorder` directive caused by `block_content` monkey patch returning None
+
 ## 2.38.7 - 2023-01-26
 
 ### Fixed

--- a/docs/source/snakemake/quickstart.md
+++ b/docs/source/snakemake/quickstart.md
@@ -22,11 +22,11 @@ $ source env/bin/activate
 $ pip install "latch[snakemake]"
 ```
 
-- Verify the Latch SDK version >= 2.38.6
+- Verify the Latch SDK version >= 2.38.8
 
 ```console
 $ latch --version
-latch, version 2.38.6
+latch, version 2.38.8
 ```
 
 ### Step 1: Generate Metadata

--- a/latch_cli/snakemake/single_task_snakemake.py
+++ b/latch_cli/snakemake/single_task_snakemake.py
@@ -231,12 +231,17 @@ def block_content_with_print_compilation(self, token):
         yield token.string, token
 
 
+def empty_generator(self, token):
+    return
+    yield
+
+
 Input.block_content = skipping_block_content
 Output.block_content = skipping_block_content
 Params.block_content = skipping_block_content
 Benchmark.block_content = skipping_block_content
 Log.block_content = skipping_block_content
-Ruleorder.block_content = lambda self, token: None
+Ruleorder.block_content = empty_generator
 Include.block_content = block_content_with_print_compilation
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if cur_ver < (3, 8) or cur_ver > (3, 11):
 
 setup(
     name="latch",
-    version="v2.38.7",
+    version="v2.38.8",
     author_email="kenny@latch.bio",
     description="The Latch SDK",
     packages=find_packages(),


### PR DESCRIPTION
block_content overrides must return a generator, not None. Otherwise, the workflow will error out.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/snakemake/__init__.py", line 654, in snakemake
    workflow.include(
  File "/usr/local/lib/python3.9/site-packages/snakemake/workflow.py", line 1213, in include
    code, linemap, rulecount = parse(
  File "/usr/local/lib/python3.9/site-packages/snakemake/parser.py", line 1274, in parse
    for t, orig_token in automaton.consume():
  File "/usr/local/lib/python3.9/site-packages/snakemake/parser.py", line 100, in consume
    for t, orig in self.state(token):
  File "/usr/local/lib/python3.9/site-packages/snakemake/parser.py", line 1226, in python
    for t in self.subautomaton(token.string).consume():
  File "/usr/local/lib/python3.9/site-packages/snakemake/parser.py", line 100, in consume
    for t, orig in self.state(token):
  File "/usr/local/lib/python3.9/site-packages/snakemake/parser.py", line 175, in block
    yield from self.block_content(token)
TypeError: 'NoneType' object is not iterable
```