### PR TITLE
Generate metadata from input parameters

### DIFF
--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -28,18 +28,14 @@ def workflow(
         if metadata is None:
             metadata = LatchMetadata(f.__name__, LatchAuthor())
             metadata.parameters = {
-                param: LatchParameter(
-                    display_name=best_effort_display_name(param),
-                    batch_table_column=True,
-                )
+                param: LatchParameter(display_name=best_effort_display_name(param))
                 for param in wf_params
             }
 
         for wf_param in wf_params:
             if wf_param not in metadata.parameters:
                 metadata.parameters[wf_param] = LatchParameter(
-                    display_name=best_effort_display_name(wf_param),
-                    batch_table_column=True,
+                    display_name=best_effort_display_name(wf_param)
                 )
 
         in_meta_not_in_wf = []

--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -1,95 +1,113 @@
 import inspect
 from dataclasses import is_dataclass
 from textwrap import dedent
-from typing import Callable, Union, get_args, get_origin
+from typing import Callable, Dict, Optional, Union, get_args, get_origin
 
 from flytekit import workflow as _workflow
 from flytekit.core.workflow import PythonFunctionWorkflow
 
-from latch.types.metadata import LatchMetadata
+from latch.types.metadata import LatchAuthor, LatchMetadata, LatchParameter
+
+
+def _generate_params(params: Dict[str, inspect.Parameter]) -> Dict[str, LatchParameter]:
+    return {param: LatchParameter(display_name=param) for param in params}
+
+
+def _inject_metadata(f: Callable, metadata: LatchMetadata) -> None:
+    if f.__doc__ is None:
+        f.__doc__ = f"{f.__name__}\n\nSample Description"
+    short_desc, long_desc = f.__doc__.split("\n", 1)
+    f.__doc__ = f"{short_desc}\n{dedent(long_desc)}\n\n" + str(metadata)
 
 
 # this weird Union thing is to ensure backwards compatibility,
 # so that when users call @workflow without any arguments or
 # parentheses, the workflow still serializes as expected
 def workflow(
-    metadata: Union[LatchMetadata, Callable]
+    metadata: Optional[Union[LatchMetadata, Callable]] = None
 ) -> Union[PythonFunctionWorkflow, Callable]:
     if isinstance(metadata, Callable):
-        return _workflow(metadata)
-    else:
+        f = metadata
+        signature = inspect.signature(f)
+        wf_params = signature.parameters
+        metadata = LatchMetadata(f.__name__, LatchAuthor())
+        metadata.parameters = _generate_params(wf_params)
 
-        def decorator(f: Callable):
-            if f.__doc__ is None:
-                f.__doc__ = f"{f.__name__}\n\nSample Description"
-            short_desc, long_desc = f.__doc__.split("\n", 1)
+        _inject_metadata(f, metadata)
+        return _workflow(f)
 
-            signature = inspect.signature(f)
-            wf_params = signature.parameters
+    def decorator(f: Callable):
+        signature = inspect.signature(f)
+        wf_params = signature.parameters
 
-            in_meta_not_in_wf = []
-            not_in_meta_in_wf = []
+        nonlocal metadata
+        if metadata is None:
+            metadata = LatchMetadata(f.__name__, LatchAuthor())
+            metadata.parameters = _generate_params(wf_params)
 
-            for meta_param in metadata.parameters:
-                if meta_param not in wf_params:
-                    in_meta_not_in_wf.append(meta_param)
+        in_meta_not_in_wf = []
+        not_in_meta_in_wf = []
 
-            for wf_param in wf_params:
-                if wf_param not in metadata.parameters:
-                    not_in_meta_in_wf.append(wf_param)
+        for meta_param in metadata.parameters:
+            if meta_param not in wf_params:
+                in_meta_not_in_wf.append(meta_param)
 
-            if len(in_meta_not_in_wf) > 0 or len(not_in_meta_in_wf) > 0:
-                error_str = (
-                    "Inconsistency detected between parameters in your `LatchMetadata`"
-                    " object and parameters in your workflow signature.\n\n"
-                )
+        for wf_param in wf_params:
+            if wf_param not in metadata.parameters:
+                not_in_meta_in_wf.append(wf_param)
 
-                if len(in_meta_not_in_wf) > 0:
-                    error_str += (
-                        "The following parameters appear in your `LatchMetadata` object"
-                        " but not in your workflow signature:\n\n"
-                    )
-                    for meta_param in in_meta_not_in_wf:
-                        error_str += f"    \x1b[1m{meta_param}\x1b[22m\n"
-                    error_str += "\n"
+        if len(in_meta_not_in_wf) > 0 or len(not_in_meta_in_wf) > 0:
+            error_str = (
+                "Inconsistency detected between parameters in your `LatchMetadata`"
+                " object and parameters in your workflow signature.\n\n"
+            )
 
-                if len(not_in_meta_in_wf) > 0:
-                    error_str += (
-                        "The following parameters appear in your workflow signature but"
-                        " not in your `LatchMetadata` object:\n\n"
-                    )
-                    for meta_param in not_in_meta_in_wf:
-                        error_str += f"    \x1b[1m{meta_param}\x1b[22m\n"
-                    error_str += "\n"
-
+            if len(in_meta_not_in_wf) > 0:
                 error_str += (
-                    "Please resolve these inconsistencies and ensure that your"
-                    " `LatchMetadata` object and workflow signature have the same"
-                    " parameters."
+                    "The following parameters appear in your `LatchMetadata` object"
+                    " but not in your workflow signature:\n\n"
+                )
+                for meta_param in in_meta_not_in_wf:
+                    error_str += f"    \x1b[1m{meta_param}\x1b[22m\n"
+                error_str += "\n"
+
+            if len(not_in_meta_in_wf) > 0:
+                error_str += (
+                    "The following parameters appear in your workflow signature but"
+                    " not in your `LatchMetadata` object:\n\n"
+                )
+                for meta_param in not_in_meta_in_wf:
+                    error_str += f"    \x1b[1m{meta_param}\x1b[22m\n"
+                error_str += "\n"
+
+            error_str += (
+                "Please resolve these inconsistencies and ensure that your"
+                " `LatchMetadata` object and workflow signature have the same"
+                " parameters."
+            )
+
+            raise ValueError(error_str)
+
+        for name, meta_param in metadata.parameters.items():
+            if meta_param.samplesheet is not True:
+                continue
+
+            annotation = wf_params[name].annotation
+
+            origin = get_origin(annotation)
+            args = get_args(annotation)
+            valid = (
+                origin is not None
+                and issubclass(origin, list)
+                and is_dataclass(args[0])
+            )
+            if not valid:
+                raise ValueError(
+                    f"parameter marked as samplesheet is not valid: {name} "
+                    f"in workflow {f.__name__} must be a list of dataclasses"
                 )
 
-                raise ValueError(error_str)
+        _inject_metadata(f, metadata)
+        return _workflow(f)
 
-            for name, meta_param in metadata.parameters.items():
-                if meta_param.samplesheet is not True:
-                    continue
-
-                annotation = wf_params[name].annotation
-
-                origin = get_origin(annotation)
-                args = get_args(annotation)
-                valid = (
-                    origin is not None
-                    and issubclass(origin, list)
-                    and is_dataclass(args[0])
-                )
-                if not valid:
-                    raise ValueError(
-                        f"parameter marked as samplesheet is not valid: {name} "
-                        f"in workflow {f.__name__} must be a list of dataclasses"
-                    )
-
-            f.__doc__ = f"{short_desc}\n{dedent(long_desc)}\n\n" + str(metadata)
-            return _workflow(f)
-
-        return decorator
+    return decorator

--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -45,47 +45,28 @@ def workflow(
             metadata = LatchMetadata(f.__name__, LatchAuthor())
             metadata.parameters = _generate_params(wf_params)
 
-        in_meta_not_in_wf = []
-        not_in_meta_in_wf = []
+        for wf_param in wf_params:
+            if wf_param not in metadata.parameters:
+                metadata.parameters[wf_param] = LatchParameter(display_name=wf_param)
 
+        in_meta_not_in_wf = []
         for meta_param in metadata.parameters:
             if meta_param not in wf_params:
                 in_meta_not_in_wf.append(meta_param)
-
-        for wf_param in wf_params:
-            if wf_param not in metadata.parameters:
-                not_in_meta_in_wf.append(wf_param)
-
-        if len(in_meta_not_in_wf) > 0 or len(not_in_meta_in_wf) > 0:
+        if len(in_meta_not_in_wf) > 0:
             error_str = (
                 "Inconsistency detected between parameters in your `LatchMetadata`"
                 " object and parameters in your workflow signature.\n\n"
+                "The following parameters appear in your `LatchMetadata` object"
+                " but not in your workflow signature:\n\n"
             )
-
-            if len(in_meta_not_in_wf) > 0:
-                error_str += (
-                    "The following parameters appear in your `LatchMetadata` object"
-                    " but not in your workflow signature:\n\n"
-                )
-                for meta_param in in_meta_not_in_wf:
-                    error_str += f"    \x1b[1m{meta_param}\x1b[22m\n"
-                error_str += "\n"
-
-            if len(not_in_meta_in_wf) > 0:
-                error_str += (
-                    "The following parameters appear in your workflow signature but"
-                    " not in your `LatchMetadata` object:\n\n"
-                )
-                for meta_param in not_in_meta_in_wf:
-                    error_str += f"    \x1b[1m{meta_param}\x1b[22m\n"
-                error_str += "\n"
-
+            for meta_param in in_meta_not_in_wf:
+                error_str += f"    \x1b[1m{meta_param}\x1b[22m\n"
             error_str += (
-                "Please resolve these inconsistencies and ensure that your"
+                "\nPlease resolve these inconsistencies and ensure that your"
                 " `LatchMetadata` object and workflow signature have the same"
                 " parameters."
             )
-
             raise ValueError(error_str)
 
         for name, meta_param in metadata.parameters.items():

--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -1,23 +1,14 @@
 import inspect
 from dataclasses import is_dataclass
 from textwrap import dedent
-from typing import Callable, Dict, Optional, Union, get_args, get_origin
+from typing import Callable, Optional, Union, get_args, get_origin
 
+import click
 from flytekit import workflow as _workflow
 from flytekit.core.workflow import PythonFunctionWorkflow
 
 from latch.types.metadata import LatchAuthor, LatchMetadata, LatchParameter
-
-
-def _generate_params(params: Dict[str, inspect.Parameter]) -> Dict[str, LatchParameter]:
-    return {param: LatchParameter(display_name=param) for param in params}
-
-
-def _inject_metadata(f: Callable, metadata: LatchMetadata) -> None:
-    if f.__doc__ is None:
-        f.__doc__ = f"{f.__name__}\n\nSample Description"
-    short_desc, long_desc = f.__doc__.split("\n", 1)
-    f.__doc__ = f"{short_desc}\n{dedent(long_desc)}\n\n" + str(metadata)
+from latch_cli.utils import best_effort_display_name
 
 
 # this weird Union thing is to ensure backwards compatibility,
@@ -27,14 +18,7 @@ def workflow(
     metadata: Optional[Union[LatchMetadata, Callable]] = None
 ) -> Union[PythonFunctionWorkflow, Callable]:
     if isinstance(metadata, Callable):
-        f = metadata
-        signature = inspect.signature(f)
-        wf_params = signature.parameters
-        metadata = LatchMetadata(f.__name__, LatchAuthor())
-        metadata.parameters = _generate_params(wf_params)
-
-        _inject_metadata(f, metadata)
-        return _workflow(f)
+        return _workflow(metadata)
 
     def decorator(f: Callable):
         signature = inspect.signature(f)
@@ -43,16 +27,26 @@ def workflow(
         nonlocal metadata
         if metadata is None:
             metadata = LatchMetadata(f.__name__, LatchAuthor())
-            metadata.parameters = _generate_params(wf_params)
+            metadata.parameters = {
+                param: LatchParameter(
+                    display_name=best_effort_display_name(param),
+                    batch_table_column=True,
+                )
+                for param in wf_params
+            }
 
         for wf_param in wf_params:
             if wf_param not in metadata.parameters:
-                metadata.parameters[wf_param] = LatchParameter(display_name=wf_param)
+                metadata.parameters[wf_param] = LatchParameter(
+                    display_name=best_effort_display_name(wf_param),
+                    batch_table_column=True,
+                )
 
         in_meta_not_in_wf = []
         for meta_param in metadata.parameters:
             if meta_param not in wf_params:
                 in_meta_not_in_wf.append(meta_param)
+
         if len(in_meta_not_in_wf) > 0:
             error_str = (
                 "Inconsistency detected between parameters in your `LatchMetadata`"
@@ -67,7 +61,8 @@ def workflow(
                 " `LatchMetadata` object and workflow signature have the same"
                 " parameters."
             )
-            raise ValueError(error_str)
+            click.secho(error_str, fg="red")
+            raise click.exceptions.Exit(1)
 
         for name, meta_param in metadata.parameters.items():
             if meta_param.samplesheet is not True:
@@ -88,7 +83,10 @@ def workflow(
                     f"in workflow {f.__name__} must be a list of dataclasses"
                 )
 
-        _inject_metadata(f, metadata)
+        if f.__doc__ is None:
+            f.__doc__ = f"{f.__name__}\n\nSample Description"
+        short_desc, long_desc = f.__doc__.split("\n", 1)
+        f.__doc__ = f"{short_desc}\n{dedent(long_desc)}\n\n" + str(metadata)
         return _workflow(f)
 
     return decorator

--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -36,7 +36,7 @@ def workflow(
 ) -> Union[PythonFunctionWorkflow, Callable]:
     if isinstance(metadata, Callable):
         f = metadata
-        if "__metadata__:" not in f.__doc__:
+        if f.__doc__ is None or "__metadata__:" not in f.__doc__:
             metadata = _generate_metadata(f)
             _inject_metadata(f, metadata)
         return _workflow(f)

--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -32,7 +32,7 @@ def _inject_metadata(f: Callable, metadata: LatchMetadata) -> None:
 # so that when users call @workflow without any arguments or
 # parentheses, the workflow still serializes as expected
 def workflow(
-    metadata: Optional[Union[LatchMetadata, Callable]] = None
+    metadata: Union[LatchMetadata, Callable]
 ) -> Union[PythonFunctionWorkflow, Callable]:
     if isinstance(metadata, Callable):
         f = metadata
@@ -44,10 +44,6 @@ def workflow(
     def decorator(f: Callable):
         signature = inspect.signature(f)
         wf_params = signature.parameters
-
-        nonlocal metadata
-        if metadata is None:
-            metadata = _generate_metadata(f)
 
         for wf_param in wf_params:
             if wf_param not in metadata.parameters:

--- a/latch_cli/snakemake/config/parser.py
+++ b/latch_cli/snakemake/config/parser.py
@@ -9,9 +9,8 @@ from typing_extensions import Annotated
 from latch.types.directory import LatchDir
 from latch.types.file import LatchFile
 from latch_cli.snakemake.utils import reindent
-from latch_cli.utils import identifier_from_str
+from latch_cli.utils import best_effort_display_name, identifier_from_str
 
-from ..serialize_utils import best_effort_display_name
 from .utils import (
     JSONValue,
     get_preamble,

--- a/latch_cli/snakemake/serialize_utils.py
+++ b/latch_cli/snakemake/serialize_utils.py
@@ -223,10 +223,3 @@ def update_mapping(cur: Path, stem: Path, remote: str, mapping: Dict[str, str]):
 
     for p in cur.iterdir():
         update_mapping(p, stem / p.name, urljoins(remote, p.name), mapping)
-
-
-underscores = re.compile(r"_+")
-
-
-def best_effort_display_name(x: str) -> str:
-    return underscores.sub(" ", x).title().strip()

--- a/latch_cli/utils/__init__.py
+++ b/latch_cli/utils/__init__.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -463,3 +464,10 @@ def check_exists_and_rename(old: Path, new: Path):
 
     for sub in old.iterdir():
         check_exists_and_rename(sub, new / sub.name)
+
+
+underscores = re.compile(r"_+")
+
+
+def best_effort_display_name(x: str) -> str:
+    return underscores.sub(" ", x).title().strip()


### PR DESCRIPTION
We should be able to generate best-effort metadata from input parameters when no metadata is provided. 

This makes it easier for user to go from script -> workflow with minimal overhead