### PR TITLE
feat: Support `Optional` samplesheet parameters

### DIFF
--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -81,16 +81,7 @@ def workflow(
             if meta_param.samplesheet is not True:
                 continue
 
-            annotation = wf_params[name].annotation
-
-            origin = get_origin(annotation)
-            args = get_args(annotation)
-            valid = (
-                origin is not None
-                and issubclass(origin, list)
-                and is_dataclass(args[0])
-            )
-            if not valid:
+            if not _is_valid_samplesheet_parameter_type(wf_param[name]):
                 click.secho(
                     f"parameter marked as samplesheet is not valid: {name} "
                     f"in workflow {f.__name__} must be a list of dataclasses",
@@ -108,3 +99,21 @@ def workflow(
         return _workflow(f, wf_name_override=wf_name_override)
 
     return decorator
+
+
+def _is_valid_samplesheet_parameter_type(parameter: inspect.Parameter) -> bool:
+    """
+    Check if a parameter in the workflow function's signature is annotated with a valid type for a
+    samplesheet LatchParameter.
+    """
+    annotation = parameter.annotation
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    valid = (
+        origin is not None
+        and issubclass(origin, list)
+        and is_dataclass(args[0])
+    )
+
+    return valid

--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -1,9 +1,14 @@
 import inspect
 import sys
-import typing
 from dataclasses import is_dataclass
 from textwrap import dedent
-from typing import Any, Callable, Dict, Union, get_args, get_origin
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Union
+from typing import _GenericAlias  # type: ignore[attr-defined]  # NB: mypy can't see private attrs
+from typing import get_args
+from typing import get_origin
 from typing_extensions import TypeAlias
 from typing_extensions import TypeGuard
 
@@ -25,8 +30,7 @@ else:
         pass
 
 
-# NB: since `_GenericAlias` is a private attribute of the `typing` module, mypy doesn't find it
-TypeAnnotation: TypeAlias = Union[type, typing._GenericAlias, UnionType]  # type: ignore[name-defined]
+TypeAnnotation: TypeAlias = Union[type, _GenericAlias, UnionType]
 """
 A function parameter's type annotation may be any of the following:
     1) `type`, when declaring any of the built-in Python types
@@ -42,8 +46,7 @@ not and must be considered explicitly.
 
 # TODO When dropping support for Python 3.9, deprecate this in favor of performing instance checks
 # directly on the `TypeAnnotation` union type.
-# NB: since `_GenericAlias` is a private attribute of the `typing` module, mypy doesn't find it
-TYPE_ANNOTATION_TYPES = (type, typing._GenericAlias, UnionType)  # type: ignore[attr-defined]
+TYPE_ANNOTATION_TYPES = (type, _GenericAlias, UnionType)  # type: ignore[attr-defined]
 
 
 def _generate_metadata(f: Callable) -> LatchMetadata:

--- a/latch/resources/workflow.py
+++ b/latch/resources/workflow.py
@@ -180,6 +180,7 @@ def _is_list_of_dataclasses_type(dtype: TypeAnnotation) -> bool:
 
     return (
         origin is not None
+        and inspect.isclass(origin)
         and issubclass(origin, list)
         and len(args) == 1
         and is_dataclass(args[0])

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -34,14 +34,24 @@ class FakeDataclass:
     bar: int
 
 
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        List[FakeDataclass],
-        Optional[List[FakeDataclass]],
-        Union[List[FakeDataclass], None],
+# Enumerate the possible ways to declare a list or optional list of dataclasses
+SAMPLESHEET_TYPES: List[TypeAnnotation] = [
+    List[FakeDataclass],
+    Optional[List[FakeDataclass]],
+    Union[List[FakeDataclass], None],
+]
+
+if sys.version_info >= (3, 10):
+    SAMPLESHEET_TYPES += [
+        list[FakeDataclass],
+        Optional[list[FakeDataclass]],
+        Union[list[FakeDataclass], None],
+        list[FakeDataclass] | None,
+        List[FakeDataclass] | None,
     ]
-)
+
+
+@pytest.mark.parametrize("dtype", SAMPLESHEET_TYPES)
 def test_is_valid_samplesheet_parameter_type(dtype: TypeAnnotation) -> None:
     """
     `_is_valid_samplesheet_parameter_type` should accept a type that is a list of dataclasses, or an

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -1,6 +1,5 @@
 import inspect
 import sys
-import typing
 from dataclasses import dataclass
 from typing import List
 from typing import Any
@@ -8,12 +7,12 @@ from typing import Collection, Iterable, Optional, Union, Mapping, Dict, Set, Tu
 
 import pytest
 
-from anno import _is_list_of_dataclasses_type
-from anno import _is_valid_samplesheet_parameter_type
-from anno import _is_optional_type
-from anno import _is_type_annotation
-from anno import _unpack_optional_type
-from anno import TypeAnnotation
+from latch.resources.workflow import _is_list_of_dataclasses_type
+from latch.resources.workflow import _is_valid_samplesheet_parameter_type
+from latch.resources.workflow import _is_optional_type
+from latch.resources.workflow import _is_type_annotation
+from latch.resources.workflow import _unpack_optional_type
+from latch.resources.workflow import TypeAnnotation
 
 PRIMITIVE_TYPES = [int, float, bool, str]
 COLLECTION_TYPES = [List[int], Dict[str, int], Set[int], Tuple[int], Mapping[str, int], Iterable[int], Collection[int]]

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -1,0 +1,124 @@
+import inspect
+import sys
+import typing
+from dataclasses import dataclass
+from typing import List
+from typing import Any
+from typing import Collection, Iterable, Optional, Union, Mapping, Dict, Set, Tuple
+
+import pytest
+
+from anno import _is_list_of_dataclasses_type
+from anno import _is_valid_samplesheet_parameter_type
+from anno import _is_optional_type
+from anno import _is_type_annotation
+from anno import _unpack_optional_type
+from anno import TypeAnnotation
+
+PRIMITIVE_TYPES = [int, float, bool, str]
+COLLECTION_TYPES = [List[int], Dict[str, int], Set[int], Tuple[int], Mapping[str, int], Iterable[int], Collection[int]]
+
+if sys.version_info >= (3, 10):
+    COLLECTION_TYPES += [list[int], dict[str, int], set[int], tuple[int]]
+
+OPTIONAL_TYPES = [Optional[T] for T in (PRIMITIVE_TYPES + COLLECTION_TYPES)]
+OPTIONAL_TYPES += [Union[T, None] for T in (PRIMITIVE_TYPES + COLLECTION_TYPES)]
+
+
+@dataclass
+class FakeDataclass:
+    """A dataclass for testing."""
+    foo: str
+    bar: int
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        List[FakeDataclass],
+        Optional[List[FakeDataclass]],
+        Union[List[FakeDataclass], None],
+    ]
+)
+def test_is_valid_samplesheet_parameter_type(dtype: TypeAnnotation) -> None:
+    """
+    `_is_valid_samplesheet_parameter_type` should accept a type that is a list of dataclasses, or an
+    `Optional` list of dataclasses.
+    """
+    parameter = inspect.Parameter("foo", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=dtype)
+    assert _is_valid_samplesheet_parameter_type(parameter) is True
+
+
+def test_is_list_of_dataclasses_type() -> None:
+    """
+    `_is_list_of_dataclasses_type` should accept a type that is a list of dataclasses.
+    """
+    assert _is_list_of_dataclasses_type(List[FakeDataclass]) is True
+
+
+@pytest.mark.parametrize("bad_type", [
+    str,  # Not a list
+    int,  # Not a list
+    List[str],  # Not a list of dataclasses
+    List[int],  # Not a list of dataclasses
+    FakeDataclass,  # Not a list
+])
+def test_is_list_of_dataclasses_type_rejects_bad_type(bad_type: type) -> None:
+    """
+    `_is_list_of_dataclasses_type` should reject anything else.
+    """
+    assert _is_list_of_dataclasses_type(bad_type) is False
+
+
+def test_is_list_of_dataclasses_type_raises_if_not_a_type() -> None:
+    """
+    `is_list_of_dataclasses_type` should raise a `TypeError` if the input is not a type.
+    """
+    with pytest.raises(TypeError):
+        _is_list_of_dataclasses_type([FakeDataclass("hello", 1)])
+
+
+@pytest.mark.parametrize("dtype", OPTIONAL_TYPES)
+def test_is_optional_type(dtype: TypeAnnotation) -> None:
+    """`_is_optional_type` should return True for `Optional[T]` types."""
+    assert _is_optional_type(dtype) is True
+
+
+@pytest.mark.parametrize("dtype", PRIMITIVE_TYPES + COLLECTION_TYPES)
+def test_is_optional_type_returns_false_if_not_optional(dtype: TypeAnnotation) -> None:
+    """`_is_optional_type` should return False for non-Optional types."""
+    assert _is_optional_type(dtype) is False
+
+
+@pytest.mark.parametrize("dtype", PRIMITIVE_TYPES + COLLECTION_TYPES)
+def test_unpack_optional_type(dtype: TypeAnnotation) -> None:
+    """`_unpack_optional_type()` should return the base type of `Optional[T]` types."""
+    assert _unpack_optional_type(Optional[dtype]) is dtype
+    assert _unpack_optional_type(Union[dtype, None]) is dtype
+    if sys.version_info >= (3, 10):
+        assert _unpack_optional_type(dtype | None) is dtype
+
+
+
+@pytest.mark.parametrize("annotation", PRIMITIVE_TYPES + COLLECTION_TYPES + OPTIONAL_TYPES)
+def test_is_type_annotation(annotation: TypeAnnotation) -> None:
+    """
+    `_is_type_annotation()` should return True for any valid type annotation.
+    """
+    assert _is_type_annotation(annotation) is True
+
+
+def test_is_type_annotation_returns_false_if_empty() -> None:
+    """
+    `_is_type_annotation()` should only return False if the annotation is `Parameter.empty`.
+    """
+    assert _is_type_annotation(inspect.Parameter.empty) is False
+
+
+@pytest.mark.parametrize("bad_annotation", [1, "abc", [1, 2], {"foo": 1}, FakeDataclass("hello", 1)])
+def test_is_type_annotation_raises_if_annotation_is_not_a_type(bad_annotation: Any) -> None:
+    """
+    `_is_type_annotation()` should raise `TypeError` for any non-type object.
+    """
+    with pytest.raises(TypeError):
+        _is_type_annotation(bad_annotation)

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -61,6 +61,15 @@ def test_is_valid_samplesheet_parameter_type(dtype: TypeAnnotation) -> None:
     assert _is_valid_samplesheet_parameter_type(parameter) is True
 
 
+@pytest.mark.parametrize("dtype", PRIMITIVE_TYPES + COLLECTION_TYPES + OPTIONAL_TYPES)
+def test_is_valid_samplesheet_parameter_type_rejects_invalid_types(dtype: TypeAnnotation) -> None:
+    """
+    `_is_valid_samplesheet_parameter_type` should reject any other type.
+    """
+    parameter = inspect.Parameter("foo", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=dtype)
+    assert _is_valid_samplesheet_parameter_type(parameter) is False
+
+
 def test_is_list_of_dataclasses_type() -> None:
     """
     `_is_list_of_dataclasses_type` should accept a type that is a list of dataclasses.

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -50,6 +50,17 @@ if sys.version_info >= (3, 10):
         List[FakeDataclass] | None,
     ]
 
+BAD_SAMPLESHEET_TYPES: List[TypeAnnotation] = PRIMITIVE_TYPES + COLLECTION_TYPES + OPTIONAL_TYPES
+BAD_SAMPLESHEET_TYPES += [
+    Union[List[FakeDataclass], int],
+    Union[Optional[List[FakeDataclass]], int],
+    Optional[Union[List[FakeDataclass], int]],
+    Union[List[FakeDataclass], Optional[int]],
+    Union[Optional[int], List[FakeDataclass]],
+    List[Union[FakeDataclass, int]],
+    List[Optional[FakeDataclass]],
+]
+
 
 @pytest.mark.parametrize("dtype", SAMPLESHEET_TYPES)
 def test_is_valid_samplesheet_parameter_type(dtype: TypeAnnotation) -> None:
@@ -60,7 +71,7 @@ def test_is_valid_samplesheet_parameter_type(dtype: TypeAnnotation) -> None:
     assert _is_valid_samplesheet_parameter_type(dtype) is True
 
 
-@pytest.mark.parametrize("dtype", PRIMITIVE_TYPES + COLLECTION_TYPES + OPTIONAL_TYPES)
+@pytest.mark.parametrize("dtype", BAD_SAMPLESHEET_TYPES)
 def test_is_valid_samplesheet_parameter_type_rejects_invalid_types(dtype: TypeAnnotation) -> None:
     """
     `_is_valid_samplesheet_parameter_type` should reject any other type.

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -57,8 +57,7 @@ def test_is_valid_samplesheet_parameter_type(dtype: TypeAnnotation) -> None:
     `_is_valid_samplesheet_parameter_type` should accept a type that is a list of dataclasses, or an
     `Optional` list of dataclasses.
     """
-    parameter = inspect.Parameter("foo", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=dtype)
-    assert _is_valid_samplesheet_parameter_type(parameter) is True
+    assert _is_valid_samplesheet_parameter_type(dtype) is True
 
 
 @pytest.mark.parametrize("dtype", PRIMITIVE_TYPES + COLLECTION_TYPES + OPTIONAL_TYPES)
@@ -66,8 +65,7 @@ def test_is_valid_samplesheet_parameter_type_rejects_invalid_types(dtype: TypeAn
     """
     `_is_valid_samplesheet_parameter_type` should reject any other type.
     """
-    parameter = inspect.Parameter("foo", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=dtype)
-    assert _is_valid_samplesheet_parameter_type(parameter) is False
+    assert _is_valid_samplesheet_parameter_type(dtype) is False
 
 
 def test_is_list_of_dataclasses_type() -> None:

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -14,14 +14,17 @@ from latch.resources.workflow import _is_type_annotation
 from latch.resources.workflow import _unpack_optional_type
 from latch.resources.workflow import TypeAnnotation
 
-PRIMITIVE_TYPES = [int, float, bool, str]
-COLLECTION_TYPES = [List[int], Dict[str, int], Set[int], Tuple[int], Mapping[str, int], Iterable[int], Collection[int]]
+PRIMITIVE_TYPES: List[type] = [int, float, bool, str]
+COLLECTION_TYPES: List[TypeAnnotation] = [List[int], Dict[str, int], Set[int], Tuple[int], Mapping[str, int], Iterable[int], Collection[int]]
 
 if sys.version_info >= (3, 10):
     COLLECTION_TYPES += [list[int], dict[str, int], set[int], tuple[int]]
 
-OPTIONAL_TYPES = [Optional[T] for T in (PRIMITIVE_TYPES + COLLECTION_TYPES)]
+OPTIONAL_TYPES: List[TypeAnnotation] = [Optional[T] for T in (PRIMITIVE_TYPES + COLLECTION_TYPES)]
 OPTIONAL_TYPES += [Union[T, None] for T in (PRIMITIVE_TYPES + COLLECTION_TYPES)]
+
+if sys.version_info >= (3, 10):
+    OPTIONAL_TYPES += [T | None for T in (PRIMITIVE_TYPES + COLLECTION_TYPES)]
 
 
 @dataclass


### PR DESCRIPTION
Workflow parameters which are mapped to rows in the Latch registry must be declared as a `list` of dataclasses in the workflow function. 

When such a parameter is part of a `ForkBranch` (e.g. when maintaining backwards compatibility for a workflow which previously supported input of a manually generated samplesheet), the parameter does not receive a value from Flyte and must have a default value defined in the workflow function signature. It would be preferable to set this default value to `None` rather than an empty list, to avoid providing a [mutable argument default](https://docs.astral.sh/ruff/rules/mutable-argument-default/).

It would be helpful if the workflow parameter could be made `Optional` to support this use case.

This PR adds support for `Optional` samplesheet parameters.