### PR TITLE
feat: Report all fields which fail registry transformation

### DIFF
--- a/latch/registry/table.py
+++ b/latch/registry/table.py
@@ -497,7 +497,8 @@ class TableUpdate:
                     v, col.upstream_type["type"], resolve_paths=False
                 )
             except RegistryTransformerException as e:
-                errs.append(f"\tCould not convert field '{k}' with value {v} to type {col.upstream_type['type']}: {e}")
+		# todo(ayush): add a registry_type -> pretty string fn so we aren't printing json here
+                errs.append(f"Error converting field {repr(k)} with value {repr(v)} to type {col.upstream_type['type']}: {e}")
 
         if len(errs) > 0:
             raise RegistryTransformerException(f"Could not upsert record {name}:" + "\n".join(errs))


### PR DESCRIPTION
Hi,

I ran into a bug that was a bit challenging to troubleshoot because the error reporting in `to_registry_literal()` does not include the name of the failing field, and only sometimes includes the failing value. 

The name of each transformed field is only in scope within `upsert_record()`,  so I thought it most sensible to catch the thrown exception there and add the relevant field and value to the error message. 

This pattern has the added benefit of validating all of the upserted values before erroring out, so in the event multiple fields are malformatted, the user can see all malformatted fields at once instead of one malformatted field per execution.