### PR TITLE
fix: latch register --yes should overwrite docker file

### DIFF
--- a/src/latch_cli/centromere/ctx.py
+++ b/src/latch_cli/centromere/ctx.py
@@ -89,6 +89,7 @@ class _CentromereCtx:
         snakefile: Optional[Path] = None,
         nf_script: Optional[Path] = None,
         use_new_centromere: bool = False,
+        docker_overwrite: bool = False
     ):
         self.use_new_centromere = use_new_centromere
         self.remote = remote
@@ -391,7 +392,7 @@ class _CentromereCtx:
 
             self.default_container = _Container(
                 dockerfile=get_default_dockerfile(
-                    self.pkg_root, wf_type=self.workflow_type
+                    self.pkg_root, wf_type=self.workflow_type, overwrite=docker_overwrite
                 ),
                 image_name=self.image_tagged,
                 pkg_dir=self.pkg_root,

--- a/src/latch_cli/docker_utils/__init__.py
+++ b/src/latch_cli/docker_utils/__init__.py
@@ -421,7 +421,7 @@ def generate_dockerignore(
     click.secho(f"Successfully generated .dockerignore `{dest}`", fg="green")
 
 
-def get_default_dockerfile(pkg_root: Path, *, wf_type: WorkflowType):
+def get_default_dockerfile(pkg_root: Path, *, wf_type: WorkflowType, overwrite: bool = False):
     default_dockerfile = pkg_root / "Dockerfile"
 
     # shitty: assumption that config is already there so base image will be ignored
@@ -431,6 +431,6 @@ def get_default_dockerfile(pkg_root: Path, *, wf_type: WorkflowType):
         default_dockerfile = pkg_root / ".latch" / "Dockerfile"
 
         builder = DockerfileBuilder(pkg_root, config, wf_type)
-        builder.generate(dest=default_dockerfile)
+        builder.generate(dest=default_dockerfile, overwrite=overwrite)
 
     return default_dockerfile


### PR DESCRIPTION
When running `latch register --yes` a second time (register locally) I get:

```console
  Dockerfile already exists at `/home/runner/work/setup-latch/setup-latch/tests/hello-world/.latch/Dockerfile`. Overwrite? [y/N]: Aborted!
```

This can even happen when the first registration is `latch register --remote`.

There's no way to force overwriting the dockerfile from the command line, and I was expected `--yes` to not prompt me.