### PR TITLE
feat: register returns a non-zero exit code based on type of failure

### DIFF
--- a/src/latch_cli/main.py
+++ b/src/latch_cli/main.py
@@ -601,6 +601,10 @@ def register(
     """Register local workflow code to Latch.
 
     Visit docs.latch.bio to learn more.
+
+    # Exit codes
+    1 - Registration failure
+    2 - Workflow already registered
     """
 
     use_new_centromere = os.environ.get("LATCH_REGISTER_BETA") is not None

--- a/src/latch_cli/services/register/register.py
+++ b/src/latch_cli/services/register/register.py
@@ -165,15 +165,17 @@ def _print_reg_resp(resp, image):
                     continue
 
                 error_str += line + "\n"
-
+        exit_code = 1
         if "task with different structure already exists" in error_str:
             error_str = (
                 f"Version {version} already exists. Make sure that you've saved any"
                 " changes you made."
             )
+            exit_code = 2
+            
 
         click.secho(f"\n{error_str}", fg="red", bold=True)
-        sys.exit(1)
+        sys.exit(exit_code)
     elif not "Successfully registered file" in resp["stdout"]:
         click.secho(
             f"\nVersion ({version}) already exists."
@@ -181,7 +183,7 @@ def _print_reg_resp(resp, image):
             fg="red",
             bold=True,
         )
-        sys.exit(1)
+        sys.exit(2)
 
     click.echo(resp.get("stdout"))
 


### PR DESCRIPTION
If the workflow was already registered, return an exit code of 2, otherwise 1.