### PR TITLE
chore: Package py.typed files with the built distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-include = ["src/**/*.py", "src/latch_cli/services/init/*"]
+include = [
+  "src/**/*.py",
+  "src/**/py.typed",
+  "src/latch_cli/services/init/*",
+]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/latch_cli" = "latch_cli"


### PR DESCRIPTION
## Summary

Third time's the charm. 😅 

The `py.typed` files were missing from the built distribution because the `pyproject.toml` was configured to include only `.py` source files. I've updated the configuration to also include `py.typed`, so these files will now be part of the distribution and available in pypi installs.

Thank you for the patience and thanks for including this!

## Changed

- Updated `pyproject.toml` so `py.typed` files in the `src/` package directories are included in the built distribution.

## Notes

I confirmed that the tarball built with `uv build` includes the `py.typed` files after this change to the `pyproject.toml`, and that no other files are added or removed.

```console
$ tar -t -f dist/latch-2.61.1.tar.gz | grep py.typed
latch-2.61.1/src/latch/py.typed
latch-2.61.1/src/latch_cli/py.typed
latch-2.61.1/src/latch_sdk_config/py.typed
latch-2.61.1/src/latch_sdk_gql/py.typed
```

```console
$ uv build && tar -t -f dist/latch-2.61.1.tar.gz > old_build.txt
$ <modify pyproject.toml>
$ uv build && tar -t -f dist/latch-2.61.1.tar.gz > new_build.txt

$ diff old_build.txt new_build.txt
3a4
> latch-2.61.1/src/latch/py.typed
70a72
> latch-2.61.1/src/latch_cli/py.typed
173a176
> latch-2.61.1/src/latch_sdk_config/py.typed
176a180
> latch-2.61.1/src/latch_sdk_gql/py.typed
```

[new_build.txt](https://github.com/user-attachments/files/19910656/new_build.txt)
[old_build.txt](https://github.com/user-attachments/files/19910657/old_build.txt)
