### PR TITLE
feat: `LPath.exists()`

### DIFF
--- a/src/latch/ldata/path.py
+++ b/src/latch/ldata/path.py
@@ -201,6 +201,14 @@ class LPath:
             self.fetch_metadata()
         return self._cache.version_id
 
+    def exists(self) -> bool:
+        """True if the Latch path points to an existing object, directory, or mount."""
+        try:
+            self.fetch_metadata()
+            return True
+        except LatchPathError:
+            return False
+
     def is_dir(self, *, load_if_missing: bool = True) -> bool:
         return self.type(load_if_missing=load_if_missing) in _dir_types
 


### PR DESCRIPTION
## Summary

Hey @ayushkamat @rahuldesai1 

I'm starting to migrate some of our workflows away from the [deprecated](https://wiki.latch.bio/workflows/sdk/defining-a-workflow/legacy-file-support) `LatchFile`/`LatchDir` API to `LPath`. I'm appreciating the ways the `LPath` API seems to mirror the standard library's `pathlib` - it should make for an easy transition. 

Would you be open to adding an `exists()` method to `LPath`, analogous to `pathlib.Path.exists()`?

There seems to be a couple ways it could be implemented - I used `self.fetch_metadata()`, but we could just as easily borrow the existence check from `LPath.mkdirp()` which uses `NodeData.exists()`. I thought it'd be preferable to use `self.fetch_metadata()` because when the user checks if a path exists, then the metadata will be cached for any following operations.