### PR TITLE
utils: fix broken traceback print in DockerException fallback

### DIFF
--- a/src/latch_cli/centromere/utils.py
+++ b/src/latch_cli/centromere/utils.py
@@ -177,8 +177,11 @@ def _construct_dkr_client(ssh_host: Optional[str] = None):
             )
             return docker.APIClient(base_url=base_url)
         except docker.errors.DockerException:
-            tracebac
-            pass
+            log.debug(
+                "Failed to connect to Docker host: unix://$HOME/run/docker.sock (%s)",
+                base_url,
+                exc_info=True,
+            )
 
         try:
             # TODO: platform specific socket defaults


### PR DESCRIPTION
Hi! Just noticed a stray unbound `tracebac` variable, probably just a typo:

https://github.com/latchbio/latch/blob/0cb43f20c1383f8f5198d07ba4d7055095cfb907/src/latch_cli/centromere/utils.py#L179-L181

Resulting in `NameError: name 'tracebac' is not defined`, when file fails to connect to user docker host, so it never tried to reach to system docker host as a fallback.

Typo was in the original code that introduced trying user docker host first - https://github.com/latchbio/latch/commit/6b1b670815a61aeac6c64eb47e36dc879b66dcae

This PR is fixing this typo and adding log line instead.