### PR TITLE
fix: fail the image upload on any docker push error

### DIFF
--- a/src/latch_cli/services/register/constants.py
+++ b/src/latch_cli/services/register/constants.py
@@ -5,3 +5,6 @@ MAX_LINES = 10
 # for parsing out ansi escape codes during register for pretty printing so
 # that e.g. carriage returns (\r) don't break the printer
 ANSI_REGEX = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+# the registry response we translate into a friendlier message
+EXPIRED_TOKEN_ERROR = "denied: Your authorization token has expired."

--- a/src/latch_cli/services/register/register.py
+++ b/src/latch_cli/services/register/register.py
@@ -8,7 +8,7 @@ import webbrowser
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Iterable, List, Optional
+from typing import Iterable, List, Optional
 
 import click
 import gql
@@ -20,9 +20,14 @@ from latch.utils import current_workspace, get_workspaces
 from latch_cli.centromere.ctx import _CentromereCtx
 from latch_cli.centromere.utils import MaybeRemoteDir
 from latch_cli.constants import latch_constants
-from latch_cli.services.register.constants import ANSI_REGEX, MAX_LINES
+from latch_cli.services.register.constants import (
+    ANSI_REGEX,
+    EXPIRED_TOKEN_ERROR,
+    MAX_LINES,
+)
 from latch_cli.services.register.utils import (
     DockerBuildLogItem,
+    DockerPushLogItem,
     build_image,
     register_serialized_pkg,
     serialize_pkg_in_container,
@@ -142,7 +147,7 @@ def print_and_write_build_logs(
 
 # todo(ayush): this sucks
 def print_upload_logs(
-    upload_image_logs: Iterable[dict[str, Any]],
+    upload_image_logs: Iterable[DockerPushLogItem],
     image: str,
     *,
     print_header: bool = True,
@@ -152,7 +157,7 @@ def print_upload_logs(
 
     prog_map: dict[str, Optional[str]] = {}
 
-    def _pp_prog_map(prog_map: dict[str, Optional[str]], prev_lines: int):
+    def _pp_prog_map(prog_map: dict[str, Optional[str]], prev_lines: int) -> int:
         if prev_lines > 0:
             click.echo("\x1b[2K\x1b[1E" * prev_lines + f"\x1b[{prev_lines}F", nl=False)
 
@@ -175,24 +180,29 @@ def print_upload_logs(
     prev_lines = 0
 
     for x in upload_image_logs:
-        if x.get("error") is not None:
-            # the cursor sits at the top of the progress block. Move below it so that the
-            # error message does not overwrite the progress lines.
+        error = x.get("error")
+        if error is not None:
+            # the cursor sits at the top of the progress block. Move below it.
             if prev_lines > 0:
                 click.echo(f"\x1b[{prev_lines}E", nl=False)
 
-            if "denied: Your authorization token has expired." in x["error"]:
+            if EXPIRED_TOKEN_ERROR in error:
                 click.secho(
                     f"Docker authorization token for {image} is expired.",
                     fg="red",
                     bold=True,
                 )
             else:
-                click.secho(x["error"], fg="red", bold=True)
+                click.secho(error, fg="red", bold=True)
 
             raise click.exceptions.Exit(1)
 
-        prog_map[x.get("id")] = x.get("progress")
+        # status-only items carry no id, and would collide on a single None key
+        layer_id = x.get("id")
+        if layer_id is None:
+            continue
+
+        prog_map[layer_id] = x.get("progress")
         prev_lines = _pp_prog_map(prog_map, prev_lines)
 
 

--- a/src/latch_cli/services/register/register.py
+++ b/src/latch_cli/services/register/register.py
@@ -8,7 +8,7 @@ import webbrowser
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable, List, Optional
+from typing import Any, Iterable, List, Optional
 
 import click
 import gql
@@ -141,7 +141,12 @@ def print_and_write_build_logs(
 
 
 # todo(ayush): this sucks
-def print_upload_logs(upload_image_logs, image, *, print_header: bool = True):
+def print_upload_logs(
+    upload_image_logs: Iterable[dict[str, Any]],
+    image: str,
+    *,
+    print_header: bool = True,
+) -> None:
     if print_header:
         click.secho("Uploading Docker image", bold=True)
 
@@ -170,16 +175,22 @@ def print_upload_logs(upload_image_logs, image, *, print_header: bool = True):
     prev_lines = 0
 
     for x in upload_image_logs:
-        if (
-            x.get("error") is not None
-            and "denied: Your authorization token has expired." in x["error"]
-        ):
-            click.secho(
-                f"\nDocker authorization token for {image} is expired.",
-                fg="red",
-                bold=True,
-            )
-            sys.exit(1)
+        if x.get("error") is not None:
+            # the cursor sits at the top of the progress block. Move below it so that the
+            # error message does not overwrite the progress lines.
+            if prev_lines > 0:
+                click.echo(f"\x1b[{prev_lines}E", nl=False)
+
+            if "denied: Your authorization token has expired." in x["error"]:
+                click.secho(
+                    f"Docker authorization token for {image} is expired.",
+                    fg="red",
+                    bold=True,
+                )
+            else:
+                click.secho(x["error"], fg="red", bold=True)
+
+            raise click.exceptions.Exit(1)
 
         prog_map[x.get("id")] = x.get("progress")
         prev_lines = _pp_prog_map(prog_map, prev_lines)

--- a/src/latch_cli/services/register/utils.py
+++ b/src/latch_cli/services/register/utils.py
@@ -100,6 +100,13 @@ class DockerBuildLogItem(TypedDict):
     stream: Optional[str]
 
 
+# a subset: the stream also carries `status` and `aux`, which holds the pushed digest
+class DockerPushLogItem(TypedDict, total=False):
+    id: str
+    error: str
+    progress: str
+
+
 def build_image(
     ctx: _CentromereCtx,
     image_name: str,
@@ -124,7 +131,7 @@ def build_image(
     return build_logs
 
 
-def upload_image(ctx: _CentromereCtx, image_name: str) -> List[str]:
+def upload_image(ctx: _CentromereCtx, image_name: str) -> Iterable[DockerPushLogItem]:
     assert ctx.dkr_client is not None
     return ctx.dkr_client.push(
         repository=f"{ctx.dkr_repo}/{image_name}", stream=True, decode=True

--- a/tests/test_print_upload_logs.py
+++ b/tests/test_print_upload_logs.py
@@ -1,0 +1,97 @@
+import click
+import pytest
+
+from latch_cli.services.register.register import print_upload_logs
+
+
+def test_progress_stream_does_not_exit():
+    """A stream with no error must run to completion."""
+    logs = [
+        {"id": "layer_a", "progress": "1/2"},
+        {"id": "layer_a", "progress": "2/2"},
+        {"id": "layer_b", "progress": "1/1"},
+    ]
+
+    print_upload_logs(logs, "test_image")
+
+
+def test_expired_token_error_exits_1():
+    logs = [{"error": "denied: Your authorization token has expired."}]
+
+    with pytest.raises(click.exceptions.Exit) as excinfo:
+        print_upload_logs(logs, "test_image")
+
+    assert excinfo.value.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        "denied: requested access to the resource is denied",
+        "received unexpected HTTP status: 500 Internal Server Error",
+        "unauthorized: authentication required",
+    ],
+)
+def test_any_error_exits_1(error: str):
+    """Every error is fatal, not just the expired-token case."""
+    with pytest.raises(click.exceptions.Exit) as excinfo:
+        print_upload_logs([{"error": error}], "test_image")
+
+    assert excinfo.value.exit_code == 1
+
+
+def test_error_text_is_shown_verbatim(capsys: pytest.CaptureFixture[str]):
+    error = "denied: requested access to the resource is denied"
+
+    with pytest.raises(click.exceptions.Exit):
+        print_upload_logs([{"error": error}], "test_image")
+
+    assert error in capsys.readouterr().out
+
+
+def test_error_stops_the_stream():
+    """Nothing after the error is read, so the caller cannot report success."""
+    consumed: list[str] = []
+
+    def logs():
+        consumed.append("first")
+        yield {"error": "denied: requested access to the resource is denied"}
+
+        consumed.append("second")
+        yield {"id": "layer_a", "progress": "1/1"}
+
+    with pytest.raises(click.exceptions.Exit):
+        print_upload_logs(logs(), "test_image")
+
+    assert consumed == ["first"]
+
+
+def test_error_after_progress_moves_below_the_progress_block(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The cursor moves below the progress block so the error is not overwritten.
+
+    `click.echo` strips escape sequences when the output is not a terminal, so record
+    the calls instead of reading the captured output.
+    """
+    written: list[str] = []
+
+    def record(message: object = "", **kwargs: object) -> None:
+        written.append(str(message))
+
+    monkeypatch.setattr(click, "echo", record)
+    monkeypatch.setattr(click, "secho", record)
+
+    logs = [
+        {"id": "layer_a", "progress": "1/2"},
+        {"error": "denied: requested access to the resource is denied"},
+    ]
+
+    with pytest.raises(click.exceptions.Exit):
+        print_upload_logs(logs, "test_image")
+
+    # one progress line was drawn, so the cursor moves down one line before the error
+    move_below = next(i for i, m in enumerate(written) if "\x1b[1E" in m)
+    error = next(i for i, m in enumerate(written) if m.startswith("denied:"))
+
+    assert move_below < error

--- a/tests/test_print_upload_logs.py
+++ b/tests/test_print_upload_logs.py
@@ -1,52 +1,63 @@
+from typing import TYPE_CHECKING
+
 import click
 import pytest
 
 from latch_cli.services.register.register import print_upload_logs
 
+if TYPE_CHECKING:
+    from latch_cli.services.register.utils import DockerPushLogItem
 
-def test_progress_stream_does_not_exit():
-    """A stream with no error must run to completion."""
-    logs = [
+
+def test_progress_stream_does_not_exit(capsys: pytest.CaptureFixture[str]):
+    """A stream with no error must run to completion, and render what it read."""
+    logs: list[DockerPushLogItem] = [
         {"id": "layer_a", "progress": "1/2"},
         {"id": "layer_a", "progress": "2/2"},
         {"id": "layer_b", "progress": "1/1"},
+        {"status": "Preparing"},  # type: ignore[typeddict-unknown-key]  # no id
     ]
 
     print_upload_logs(logs, "test_image")
 
+    out = capsys.readouterr().out
+    assert "layer_a ~ 2/2" in out
+    assert "layer_b ~ 1/1" in out
+    assert "None ~" not in out
 
-def test_expired_token_error_exits_1():
-    logs = [{"error": "denied: Your authorization token has expired."}]
+
+def test_pull_path_reports_errors_too(capsys: pytest.CaptureFixture[str]):
+    """The pull stream uses the same parser, with the header suppressed."""
+    error = "manifest for barcode-analysis/barcode-tools:v1 not found"
 
     with pytest.raises(click.exceptions.Exit) as excinfo:
-        print_upload_logs(logs, "test_image")
+        print_upload_logs([{"error": error}], "test_image", print_header=False)
 
     assert excinfo.value.exit_code == 1
 
+    out = capsys.readouterr().out
+    assert error in out
+    assert "Uploading Docker image" not in out
+
 
 @pytest.mark.parametrize(
-    "error",
+    ("error", "expected"),
     [
-        "denied: requested access to the resource is denied",
-        "received unexpected HTTP status: 500 Internal Server Error",
-        "unauthorized: authentication required",
+        ("denied: Your authorization token has expired.", "is expired"),
+        ("denied: requested access to the resource is denied", "denied: requested"),
+        ("received unexpected HTTP status: 500 Internal Server Error", "500"),
+        ("unauthorized: authentication required", "unauthorized"),
     ],
 )
-def test_any_error_exits_1(error: str):
+def test_every_error_exits_1_and_is_shown(
+    error: str, expected: str, capsys: pytest.CaptureFixture[str]
+):
     """Every error is fatal, not just the expired-token case."""
     with pytest.raises(click.exceptions.Exit) as excinfo:
         print_upload_logs([{"error": error}], "test_image")
 
     assert excinfo.value.exit_code == 1
-
-
-def test_error_text_is_shown_verbatim(capsys: pytest.CaptureFixture[str]):
-    error = "denied: requested access to the resource is denied"
-
-    with pytest.raises(click.exceptions.Exit):
-        print_upload_logs([{"error": error}], "test_image")
-
-    assert error in capsys.readouterr().out
+    assert expected in capsys.readouterr().out
 
 
 def test_error_stops_the_stream():
@@ -76,7 +87,7 @@ def test_error_after_progress_moves_below_the_progress_block(
     """
     written: list[str] = []
 
-    def record(message: object = "", **kwargs: object) -> None:
+    def record(message: object = "", **_kwargs: object) -> None:
         written.append(str(message))
 
     monkeypatch.setattr(click, "echo", record)
@@ -90,8 +101,9 @@ def test_error_after_progress_moves_below_the_progress_block(
     with pytest.raises(click.exceptions.Exit):
         print_upload_logs(logs, "test_image")
 
-    # one progress line was drawn, so the cursor moves down one line before the error
-    move_below = next(i for i, m in enumerate(written) if "\x1b[1E" in m)
+    # match the exact echo: the redraw prefix also contains `\x1b[1E`, so a substring
+    # test would pass with the cursor move deleted as soon as the fixture grows
+    move_below = written.index("\x1b[1E")
     error = next(i for i, m in enumerate(written) if m.startswith("denied:"))
 
     assert move_below < error

--- a/tests/test_print_upload_logs.py
+++ b/tests/test_print_upload_logs.py
@@ -21,6 +21,7 @@ def test_progress_stream_does_not_exit(capsys: pytest.CaptureFixture[str]):
     print_upload_logs(logs, "test_image")
 
     out = capsys.readouterr().out
+    assert "Uploading Docker image" in out  # header prints when not suppressed
     assert "layer_a ~ 2/2" in out
     assert "layer_b ~ 1/1" in out
     assert "None ~" not in out


### PR DESCRIPTION
Previously only an expired-registry-token error stopped the upload; every other push-stream error (denied, unauthorized, 5xx) was ignored and the upload reported success. Now any error in the push stream aborts with exit 1 and prints the error.

**Changes**
- Treat every docker push-stream error as fatal, not just the expired-token case.
- Type the decoded push/pull stream and lift the expired-token string to a constant.
- Ignore status-only stream frames so they no longer render a stray `None` row.

**Tests:** error propagation and the header print/suppress paths.
