### PR TITLE
fix: separate image-record failures from push failures

### DIFF
--- a/src/latch_cli/main.py
+++ b/src/latch_cli/main.py
@@ -613,8 +613,13 @@ def upload_image(
     image_name: Optional[str] = None,
     version: Optional[str] = None,
     yes: bool = False,
-):
-    """Uploads an existing Docker image to Latch ECR"""
+) -> None:
+    """Uploads an existing Docker image to Latch ECR
+
+    Exits 0 if the image is in the registry and Latch has a record of it, 1 if the
+    image did not reach the registry, and 3 if the image is in the registry but Latch
+    could not record it.
+    """
 
     from .services.private_images import upload_image
 

--- a/src/latch_cli/services/private_images.py
+++ b/src/latch_cli/services/private_images.py
@@ -77,8 +77,10 @@ def is_recorded_in_db(ws_id: str, image_name: str, version: str) -> bool:
 
     # match again client-side: a false positive here makes `record_in_db` skip the
     # create and report success for a record that never landed.
+    # `workspaceId` comes from the `BigInt` scalar, which can serialize as a JSON
+    # number; normalise to str so the comparison never silently fails to match.
     return any(
-        node["workspaceId"] == ws_id
+        str(node["workspaceId"]) == ws_id
         and node["imageName"] == image_name
         and node["version"] == version
         for node in res["nodes"]

--- a/src/latch_cli/services/private_images.py
+++ b/src/latch_cli/services/private_images.py
@@ -20,8 +20,58 @@ from .register.register import print_upload_logs
 
 ecr_base = config.dkr_repo
 
+# exit code used when the image reached the registry but the database record did not. A
+# caller that sees this must not push the image again - the tag is already taken.
+record_failed_exit_code = 3
 
-def record_in_db(ws_id: str, image_name: str, version: str):
+
+class PrivateImageNode(TypedDict):
+    imageName: str
+    version: str
+    creationTime: str
+
+
+class PrivateImages(TypedDict):
+    nodes: Optional[list[PrivateImageNode]]
+
+
+def is_recorded_in_db(ws_id: str, image_name: str, version: str) -> bool:
+    """Report whether the workspace already has a record of this image and version."""
+    res: Optional[PrivateImages] = execute(
+        gql.gql("""
+            query PrivateImageExists(
+                $wsId: BigInt!
+                $imageName: String!
+                $version: String!
+            ) {
+                privateImages(
+                    filter: {
+                        workspaceId: { equalTo: $wsId }
+                        imageName: { equalTo: $imageName }
+                        version: { equalTo: $version }
+                    }
+                ) {
+                    nodes {
+                        imageName
+                        version
+                        creationTime
+                    }
+                }
+            }
+        """),
+        {"wsId": ws_id, "imageName": image_name, "version": version},
+    )["privateImages"]
+
+    return res is not None and bool(res["nodes"])
+
+
+def record_in_db(ws_id: str, image_name: str, version: str) -> None:
+    # the mutation is a plain create, so a second call for the same image and version
+    # fails on the uniqueness constraint. Skip it if the record is already there, which
+    # makes a retry of a partly completed upload safe.
+    if is_recorded_in_db(ws_id, image_name, version):
+        return
+
     execute(
         gql.gql("""
             mutation AddStagingImage(
@@ -44,6 +94,34 @@ def record_in_db(ws_id: str, image_name: str, version: str):
         """),
         {"wsId": ws_id, "imageName": image_name, "version": version},
     )
+
+
+def record_in_db_or_exit(
+    ws_id: str, image_name: str, version: str, full_image_ref: str
+) -> None:
+    """Record an image that is already in the registry, or exit with a distinct code.
+
+    Call this only after the push succeeds. A failure here means the image is in the
+    registry but Latch does not know about it, which a caller must not treat the same
+    way as a failed push.
+    """
+    try:
+        record_in_db(ws_id, image_name, version)
+    except Exception as e:
+        click.secho(
+            dedent(f"""\
+                The image reached the registry, but Latch could not record it:
+
+                  {e}
+
+                `{full_image_ref}` is in the registry and its tag cannot be reused. Do
+                not run this command again with the same version.
+            """),
+            fg="red",
+            bold=True,
+        )
+
+        raise click.exceptions.Exit(record_failed_exit_code) from e
 
 
 # note(ayush): latch register, etc. do a simplified version of this that can unnecessarily reformat
@@ -122,7 +200,7 @@ def upload_image(
     image_name: Optional[str] = None,
     version: Optional[str] = None,
     skip_confirmation: bool = False,
-):
+) -> None:
     click.secho("Beginning image upload:")
     match = image_ref_expr.match(image_ref)
 
@@ -207,9 +285,9 @@ def upload_image(
         namespaced_image_name,
     )
 
-    record_in_db(ws_id, namespaced_image_name, version)
+    click.secho(f"Successfully pushed {full_image_ref}", fg="green")
 
-    click.secho(f"Successfully built and tagged {full_image_ref}", fg="green")
+    record_in_db_or_exit(ws_id, namespaced_image_name, version, full_image_ref)
 
 
 def build_and_upload_image(
@@ -221,7 +299,7 @@ def build_and_upload_image(
     remote: bool = True,
     skip_confirmation: bool = False,
     progress_plain: bool = False,
-):
+) -> None:
     click.secho("Beginning image build and upload:")
 
     validate_image_name(image_name)
@@ -281,19 +359,9 @@ def build_and_upload_image(
             progress_plain=progress_plain,
         )
 
-    record_in_db(ws_id, namespaced_image_name, version)
-
     click.secho(f"Successfully built and tagged {full_image_ref}", fg="green")
 
-
-class PrivateImageNode(TypedDict):
-    imageName: str
-    version: str
-    creationTime: str
-
-
-class PrivateImages(TypedDict):
-    nodes: Optional[list[PrivateImageNode]]
+    record_in_db_or_exit(ws_id, namespaced_image_name, version, full_image_ref)
 
 
 # todo(ayush): scuffed

--- a/src/latch_cli/services/private_images.py
+++ b/src/latch_cli/services/private_images.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import asdict
 from pathlib import Path
-from textwrap import dedent
+from textwrap import dedent, indent
 from typing import Optional, TypedDict
 
 import click
@@ -20,15 +20,15 @@ from .register.register import print_upload_logs
 
 ecr_base = config.dkr_repo
 
-# exit code used when the image reached the registry but the database record did not. A
-# caller that sees this must not push the image again - the tag is already taken.
+# the image reached the registry but the record did not. Distinct from 1 so a caller
+# can tell "not published" from "published but unrecorded".
 record_failed_exit_code = 3
 
 
 class PrivateImageNode(TypedDict):
+    workspaceId: str
     imageName: str
     version: str
-    creationTime: str
 
 
 class PrivateImages(TypedDict):
@@ -52,9 +52,9 @@ def is_recorded_in_db(ws_id: str, image_name: str, version: str) -> bool:
                     }
                 ) {
                     nodes {
+                        workspaceId
                         imageName
                         version
-                        creationTime
                     }
                 }
             }
@@ -62,13 +62,22 @@ def is_recorded_in_db(ws_id: str, image_name: str, version: str) -> bool:
         {"wsId": ws_id, "imageName": image_name, "version": version},
     )["privateImages"]
 
-    return res is not None and bool(res["nodes"])
+    if res is None or res["nodes"] is None:
+        return False
+
+    # match again client-side: a false positive here makes `record_in_db` skip the
+    # create and report success for a record that never landed.
+    return any(
+        node["workspaceId"] == ws_id
+        and node["imageName"] == image_name
+        and node["version"] == version
+        for node in res["nodes"]
+    )
 
 
 def record_in_db(ws_id: str, image_name: str, version: str) -> None:
-    # the mutation is a plain create, so a second call for the same image and version
-    # fails on the uniqueness constraint. Skip it if the record is already there, which
-    # makes a retry of a partly completed upload safe.
+    # the mutation is a plain create, so a repeat call fails on the uniqueness
+    # constraint. Skipping it makes a retry of a partly completed upload safe.
     if is_recorded_in_db(ws_id, image_name, version):
         return
 
@@ -97,26 +106,37 @@ def record_in_db(ws_id: str, image_name: str, version: str) -> None:
 
 
 def record_in_db_or_exit(
-    ws_id: str, image_name: str, version: str, full_image_ref: str
+    ws_id: str, image_name: str, version: str, *, full_image_ref: str
 ) -> None:
-    """Record an image that is already in the registry, or exit with a distinct code.
+    """Record an image already in the registry, or exit with a distinct code.
 
-    Call this only after the push succeeds. A failure here means the image is in the
-    registry but Latch does not know about it, which a caller must not treat the same
-    way as a failed push.
+    Call only after the push succeeds: a failure here means the image is published but
+    unrecorded, which a caller must not treat like a failed push.
     """
     try:
         record_in_db(ws_id, image_name, version)
+    # both subclass RuntimeError, so `except Exception` would relabel them as a
+    # record failure and swallow the real exit code
+    except (click.exceptions.Exit, click.Abort):
+        raise
     except Exception as e:
+        # dedent the template first: interpolating a multi-line error would leave a
+        # zero-indent line, and dedent would then strip nothing from the whole block
+        template = dedent("""\
+            The image reached the registry, but Latch could not record it:
+
+            {error}
+
+            `{ref}` is pushed, but Latch has no record of it. It will not appear in
+            `latch image ls`, and workflows cannot reference it.
+
+            Re-run this command to retry the record. The record step skips itself if
+            the record already exists. If the registry refuses the repeated push
+            because the tag is immutable, upload under a new version instead.
+        """)
+
         click.secho(
-            dedent(f"""\
-                The image reached the registry, but Latch could not record it:
-
-                  {e}
-
-                `{full_image_ref}` is in the registry and its tag cannot be reused. Do
-                not run this command again with the same version.
-            """),
+            template.format(error=indent(str(e), "  "), ref=full_image_ref),
             fg="red",
             bold=True,
         )
@@ -287,7 +307,9 @@ def upload_image(
 
     click.secho(f"Successfully pushed {full_image_ref}", fg="green")
 
-    record_in_db_or_exit(ws_id, namespaced_image_name, version, full_image_ref)
+    record_in_db_or_exit(
+        ws_id, namespaced_image_name, version, full_image_ref=full_image_ref
+    )
 
 
 def build_and_upload_image(
@@ -361,7 +383,9 @@ def build_and_upload_image(
 
     click.secho(f"Successfully built and tagged {full_image_ref}", fg="green")
 
-    record_in_db_or_exit(ws_id, namespaced_image_name, version, full_image_ref)
+    record_in_db_or_exit(
+        ws_id, namespaced_image_name, version, full_image_ref=full_image_ref
+    )
 
 
 # todo(ayush): scuffed

--- a/src/latch_cli/services/private_images.py
+++ b/src/latch_cli/services/private_images.py
@@ -26,18 +26,28 @@ record_failed_exit_code = 3
 
 
 class PrivateImageNode(TypedDict):
-    workspaceId: str
     imageName: str
     version: str
+    creationTime: str
 
 
 class PrivateImages(TypedDict):
     nodes: Optional[list[PrivateImageNode]]
 
 
+class PrivateImageExistsNode(TypedDict):
+    workspaceId: str
+    imageName: str
+    version: str
+
+
+class PrivateImageExistsResult(TypedDict):
+    nodes: Optional[list[PrivateImageExistsNode]]
+
+
 def is_recorded_in_db(ws_id: str, image_name: str, version: str) -> bool:
     """Report whether the workspace already has a record of this image and version."""
-    res: Optional[PrivateImages] = execute(
+    res: Optional[PrivateImageExistsResult] = execute(
         gql.gql("""
             query PrivateImageExists(
                 $wsId: BigInt!

--- a/src/latch_cli/services/register/constants.py
+++ b/src/latch_cli/services/register/constants.py
@@ -5,3 +5,6 @@ MAX_LINES = 10
 # for parsing out ansi escape codes during register for pretty printing so
 # that e.g. carriage returns (\r) don't break the printer
 ANSI_REGEX = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+# the registry response we translate into a friendlier message
+EXPIRED_TOKEN_ERROR = "denied: Your authorization token has expired."

--- a/src/latch_cli/services/register/register.py
+++ b/src/latch_cli/services/register/register.py
@@ -8,7 +8,7 @@ import webbrowser
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Iterable, List, Optional
+from typing import Iterable, List, Optional
 
 import click
 import gql
@@ -20,9 +20,14 @@ from latch.utils import current_workspace, get_workspaces
 from latch_cli.centromere.ctx import _CentromereCtx
 from latch_cli.centromere.utils import MaybeRemoteDir
 from latch_cli.constants import latch_constants
-from latch_cli.services.register.constants import ANSI_REGEX, MAX_LINES
+from latch_cli.services.register.constants import (
+    ANSI_REGEX,
+    EXPIRED_TOKEN_ERROR,
+    MAX_LINES,
+)
 from latch_cli.services.register.utils import (
     DockerBuildLogItem,
+    DockerPushLogItem,
     build_image,
     register_serialized_pkg,
     serialize_pkg_in_container,
@@ -142,7 +147,7 @@ def print_and_write_build_logs(
 
 # todo(ayush): this sucks
 def print_upload_logs(
-    upload_image_logs: Iterable[dict[str, Any]],
+    upload_image_logs: Iterable[DockerPushLogItem],
     image: str,
     *,
     print_header: bool = True,
@@ -152,7 +157,7 @@ def print_upload_logs(
 
     prog_map: dict[str, Optional[str]] = {}
 
-    def _pp_prog_map(prog_map: dict[str, Optional[str]], prev_lines: int):
+    def _pp_prog_map(prog_map: dict[str, Optional[str]], prev_lines: int) -> int:
         if prev_lines > 0:
             click.echo("\x1b[2K\x1b[1E" * prev_lines + f"\x1b[{prev_lines}F", nl=False)
 
@@ -175,24 +180,29 @@ def print_upload_logs(
     prev_lines = 0
 
     for x in upload_image_logs:
-        if x.get("error") is not None:
-            # the cursor sits at the top of the progress block. Move below it so that the
-            # error message does not overwrite the progress lines.
+        error = x.get("error")
+        if error is not None:
+            # the cursor sits at the top of the progress block. Move below it.
             if prev_lines > 0:
                 click.echo(f"\x1b[{prev_lines}E", nl=False)
 
-            if "denied: Your authorization token has expired." in x["error"]:
+            if EXPIRED_TOKEN_ERROR in error:
                 click.secho(
                     f"Docker authorization token for {image} is expired.",
                     fg="red",
                     bold=True,
                 )
             else:
-                click.secho(x["error"], fg="red", bold=True)
+                click.secho(error, fg="red", bold=True)
 
             raise click.exceptions.Exit(1)
 
-        prog_map[x.get("id")] = x.get("progress")
+        # status-only items carry no id, and would collide on a single None key
+        layer_id = x.get("id")
+        if layer_id is None:
+            continue
+
+        prog_map[layer_id] = x.get("progress")
         prev_lines = _pp_prog_map(prog_map, prev_lines)
 
 

--- a/src/latch_cli/services/register/register.py
+++ b/src/latch_cli/services/register/register.py
@@ -8,7 +8,7 @@ import webbrowser
 from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable, List, Optional
+from typing import Any, Iterable, List, Optional
 
 import click
 import gql
@@ -141,7 +141,12 @@ def print_and_write_build_logs(
 
 
 # todo(ayush): this sucks
-def print_upload_logs(upload_image_logs, image, *, print_header: bool = True):
+def print_upload_logs(
+    upload_image_logs: Iterable[dict[str, Any]],
+    image: str,
+    *,
+    print_header: bool = True,
+) -> None:
     if print_header:
         click.secho("Uploading Docker image", bold=True)
 
@@ -170,16 +175,22 @@ def print_upload_logs(upload_image_logs, image, *, print_header: bool = True):
     prev_lines = 0
 
     for x in upload_image_logs:
-        if (
-            x.get("error") is not None
-            and "denied: Your authorization token has expired." in x["error"]
-        ):
-            click.secho(
-                f"\nDocker authorization token for {image} is expired.",
-                fg="red",
-                bold=True,
-            )
-            sys.exit(1)
+        if x.get("error") is not None:
+            # the cursor sits at the top of the progress block. Move below it so that the
+            # error message does not overwrite the progress lines.
+            if prev_lines > 0:
+                click.echo(f"\x1b[{prev_lines}E", nl=False)
+
+            if "denied: Your authorization token has expired." in x["error"]:
+                click.secho(
+                    f"Docker authorization token for {image} is expired.",
+                    fg="red",
+                    bold=True,
+                )
+            else:
+                click.secho(x["error"], fg="red", bold=True)
+
+            raise click.exceptions.Exit(1)
 
         prog_map[x.get("id")] = x.get("progress")
         prev_lines = _pp_prog_map(prog_map, prev_lines)

--- a/src/latch_cli/services/register/utils.py
+++ b/src/latch_cli/services/register/utils.py
@@ -100,6 +100,13 @@ class DockerBuildLogItem(TypedDict):
     stream: Optional[str]
 
 
+# a subset: the stream also carries `status` and `aux`, which holds the pushed digest
+class DockerPushLogItem(TypedDict, total=False):
+    id: str
+    error: str
+    progress: str
+
+
 def build_image(
     ctx: _CentromereCtx,
     image_name: str,
@@ -124,7 +131,7 @@ def build_image(
     return build_logs
 
 
-def upload_image(ctx: _CentromereCtx, image_name: str) -> List[str]:
+def upload_image(ctx: _CentromereCtx, image_name: str) -> Iterable[DockerPushLogItem]:
     assert ctx.dkr_client is not None
     return ctx.dkr_client.push(
         repository=f"{ctx.dkr_repo}/{image_name}", stream=True, decode=True

--- a/tests/test_print_upload_logs.py
+++ b/tests/test_print_upload_logs.py
@@ -1,0 +1,97 @@
+import click
+import pytest
+
+from latch_cli.services.register.register import print_upload_logs
+
+
+def test_progress_stream_does_not_exit():
+    """A stream with no error must run to completion."""
+    logs = [
+        {"id": "layer_a", "progress": "1/2"},
+        {"id": "layer_a", "progress": "2/2"},
+        {"id": "layer_b", "progress": "1/1"},
+    ]
+
+    print_upload_logs(logs, "test_image")
+
+
+def test_expired_token_error_exits_1():
+    logs = [{"error": "denied: Your authorization token has expired."}]
+
+    with pytest.raises(click.exceptions.Exit) as excinfo:
+        print_upload_logs(logs, "test_image")
+
+    assert excinfo.value.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        "denied: requested access to the resource is denied",
+        "received unexpected HTTP status: 500 Internal Server Error",
+        "unauthorized: authentication required",
+    ],
+)
+def test_any_error_exits_1(error: str):
+    """Every error is fatal, not just the expired-token case."""
+    with pytest.raises(click.exceptions.Exit) as excinfo:
+        print_upload_logs([{"error": error}], "test_image")
+
+    assert excinfo.value.exit_code == 1
+
+
+def test_error_text_is_shown_verbatim(capsys: pytest.CaptureFixture[str]):
+    error = "denied: requested access to the resource is denied"
+
+    with pytest.raises(click.exceptions.Exit):
+        print_upload_logs([{"error": error}], "test_image")
+
+    assert error in capsys.readouterr().out
+
+
+def test_error_stops_the_stream():
+    """Nothing after the error is read, so the caller cannot report success."""
+    consumed: list[str] = []
+
+    def logs():
+        consumed.append("first")
+        yield {"error": "denied: requested access to the resource is denied"}
+
+        consumed.append("second")
+        yield {"id": "layer_a", "progress": "1/1"}
+
+    with pytest.raises(click.exceptions.Exit):
+        print_upload_logs(logs(), "test_image")
+
+    assert consumed == ["first"]
+
+
+def test_error_after_progress_moves_below_the_progress_block(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The cursor moves below the progress block so the error is not overwritten.
+
+    `click.echo` strips escape sequences when the output is not a terminal, so record
+    the calls instead of reading the captured output.
+    """
+    written: list[str] = []
+
+    def record(message: object = "", **kwargs: object) -> None:
+        written.append(str(message))
+
+    monkeypatch.setattr(click, "echo", record)
+    monkeypatch.setattr(click, "secho", record)
+
+    logs = [
+        {"id": "layer_a", "progress": "1/2"},
+        {"error": "denied: requested access to the resource is denied"},
+    ]
+
+    with pytest.raises(click.exceptions.Exit):
+        print_upload_logs(logs, "test_image")
+
+    # one progress line was drawn, so the cursor moves down one line before the error
+    move_below = next(i for i, m in enumerate(written) if "\x1b[1E" in m)
+    error = next(i for i, m in enumerate(written) if m.startswith("denied:"))
+
+    assert move_below < error

--- a/tests/test_print_upload_logs.py
+++ b/tests/test_print_upload_logs.py
@@ -1,52 +1,63 @@
+from typing import TYPE_CHECKING
+
 import click
 import pytest
 
 from latch_cli.services.register.register import print_upload_logs
 
+if TYPE_CHECKING:
+    from latch_cli.services.register.utils import DockerPushLogItem
 
-def test_progress_stream_does_not_exit():
-    """A stream with no error must run to completion."""
-    logs = [
+
+def test_progress_stream_does_not_exit(capsys: pytest.CaptureFixture[str]):
+    """A stream with no error must run to completion, and render what it read."""
+    logs: list[DockerPushLogItem] = [
         {"id": "layer_a", "progress": "1/2"},
         {"id": "layer_a", "progress": "2/2"},
         {"id": "layer_b", "progress": "1/1"},
+        {"status": "Preparing"},  # type: ignore[typeddict-unknown-key]  # no id
     ]
 
     print_upload_logs(logs, "test_image")
 
+    out = capsys.readouterr().out
+    assert "layer_a ~ 2/2" in out
+    assert "layer_b ~ 1/1" in out
+    assert "None ~" not in out
 
-def test_expired_token_error_exits_1():
-    logs = [{"error": "denied: Your authorization token has expired."}]
+
+def test_pull_path_reports_errors_too(capsys: pytest.CaptureFixture[str]):
+    """The pull stream uses the same parser, with the header suppressed."""
+    error = "manifest for barcode-analysis/barcode-tools:v1 not found"
 
     with pytest.raises(click.exceptions.Exit) as excinfo:
-        print_upload_logs(logs, "test_image")
+        print_upload_logs([{"error": error}], "test_image", print_header=False)
 
     assert excinfo.value.exit_code == 1
 
+    out = capsys.readouterr().out
+    assert error in out
+    assert "Uploading Docker image" not in out
+
 
 @pytest.mark.parametrize(
-    "error",
+    ("error", "expected"),
     [
-        "denied: requested access to the resource is denied",
-        "received unexpected HTTP status: 500 Internal Server Error",
-        "unauthorized: authentication required",
+        ("denied: Your authorization token has expired.", "is expired"),
+        ("denied: requested access to the resource is denied", "denied: requested"),
+        ("received unexpected HTTP status: 500 Internal Server Error", "500"),
+        ("unauthorized: authentication required", "unauthorized"),
     ],
 )
-def test_any_error_exits_1(error: str):
+def test_every_error_exits_1_and_is_shown(
+    error: str, expected: str, capsys: pytest.CaptureFixture[str]
+):
     """Every error is fatal, not just the expired-token case."""
     with pytest.raises(click.exceptions.Exit) as excinfo:
         print_upload_logs([{"error": error}], "test_image")
 
     assert excinfo.value.exit_code == 1
-
-
-def test_error_text_is_shown_verbatim(capsys: pytest.CaptureFixture[str]):
-    error = "denied: requested access to the resource is denied"
-
-    with pytest.raises(click.exceptions.Exit):
-        print_upload_logs([{"error": error}], "test_image")
-
-    assert error in capsys.readouterr().out
+    assert expected in capsys.readouterr().out
 
 
 def test_error_stops_the_stream():
@@ -76,7 +87,7 @@ def test_error_after_progress_moves_below_the_progress_block(
     """
     written: list[str] = []
 
-    def record(message: object = "", **kwargs: object) -> None:
+    def record(message: object = "", **_kwargs: object) -> None:
         written.append(str(message))
 
     monkeypatch.setattr(click, "echo", record)
@@ -90,8 +101,9 @@ def test_error_after_progress_moves_below_the_progress_block(
     with pytest.raises(click.exceptions.Exit):
         print_upload_logs(logs, "test_image")
 
-    # one progress line was drawn, so the cursor moves down one line before the error
-    move_below = next(i for i, m in enumerate(written) if "\x1b[1E" in m)
+    # match the exact echo: the redraw prefix also contains `\x1b[1E`, so a substring
+    # test would pass with the cursor move deleted as soon as the fixture grows
+    move_below = written.index("\x1b[1E")
     error = next(i for i, m in enumerate(written) if m.startswith("denied:"))
 
     assert move_below < error

--- a/tests/test_print_upload_logs.py
+++ b/tests/test_print_upload_logs.py
@@ -21,6 +21,7 @@ def test_progress_stream_does_not_exit(capsys: pytest.CaptureFixture[str]):
     print_upload_logs(logs, "test_image")
 
     out = capsys.readouterr().out
+    assert "Uploading Docker image" in out  # header prints when not suppressed
     assert "layer_a ~ 2/2" in out
     assert "layer_b ~ 1/1" in out
     assert "None ~" not in out

--- a/tests/test_private_images.py
+++ b/tests/test_private_images.py
@@ -173,6 +173,22 @@ def test_record_in_db_or_exit_passes_through_a_click_exit(
     assert excinfo.value.exit_code == 1
 
 
+def test_record_in_db_or_exit_passes_through_a_click_abort(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A click abort from below must propagate, not be relabelled as 3."""
+
+    def raises(_ws_id: str, _image_name: str, _version: str) -> None:
+        raise click.Abort
+
+    monkeypatch.setattr(private_images, "record_in_db", raises)
+
+    with pytest.raises(click.Abort):
+        record_in_db_or_exit(
+            WS_ID, IMAGE_NAME, VERSION, full_image_ref="ecr/image:abc123"
+        )
+
+
 def test_record_failure_message_survives_a_multiline_error(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ):

--- a/tests/test_private_images.py
+++ b/tests/test_private_images.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any, Optional
 
 import click
@@ -16,63 +17,88 @@ WS_ID = "1234"
 IMAGE_NAME = "1234_barcode_tools"
 VERSION = "abc123"
 
-RECORDED_NODE = {
+RECORDED_NODE = {"workspaceId": WS_ID, "imageName": IMAGE_NAME, "version": VERSION}
+OTHER_WORKSPACE_NODE = {
+    "workspaceId": "9999",
     "imageName": IMAGE_NAME,
     "version": VERSION,
-    "creationTime": "2026-08-12T00:00:00Z",
 }
 
 
-def fake_execute(response: Optional[dict[str, Any]], calls: list[str]):
-    """Return a stand-in for `execute` that records the operation of each call."""
+def fake_execute(
+    response: Optional[dict[str, Any]], calls: list[tuple[str, Any]]
+) -> Callable[..., dict[str, Any]]:
+    """Return a stand-in for `execute` that records the document and its variables."""
 
-    def execute(document: graphql.DocumentNode, variables=None, **kwargs):
-        calls.append(graphql.print_ast(document))
+    def execute(
+        document: graphql.DocumentNode,
+        variables: Optional[dict[str, Any]] = None,
+        **_kwargs: object,
+    ) -> dict[str, Any]:
+        calls.append((graphql.print_ast(document), variables))
 
         return {"privateImages": response}
 
     return execute
 
 
-def test_is_recorded_in_db_finds_the_image(monkeypatch: pytest.MonkeyPatch):
-    calls: list[str] = []
-    monkeypatch.setattr(
-        private_images, "execute", fake_execute({"nodes": [RECORDED_NODE]}, calls)
-    )
+OTHER_IMAGE_NODE = {
+    "workspaceId": WS_ID,
+    "imageName": "1234_other_tool",
+    "version": VERSION,
+}
+OTHER_VERSION_NODE = {
+    "workspaceId": WS_ID,
+    "imageName": IMAGE_NAME,
+    "version": "zzz999",
+}
 
-    assert is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION) is True
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"nodes": [RECORDED_NODE]}, True),
+        ({"nodes": [OTHER_IMAGE_NODE]}, False),
+        ({"nodes": [OTHER_VERSION_NODE]}, False),
+        ({"nodes": [OTHER_WORKSPACE_NODE]}, False),
+        ({"nodes": [OTHER_IMAGE_NODE, RECORDED_NODE]}, True),
+        ({"nodes": []}, False),
+        ({"nodes": None}, False),
+        (None, False),
+    ],
+)
+def test_is_recorded_in_db(
+    monkeypatch: pytest.MonkeyPatch,
+    response: Optional[dict[str, Any]],
+    *,
+    expected: bool,
+):
+    """Only a node matching both the image and the version counts as recorded."""
+    monkeypatch.setattr(private_images, "execute", fake_execute(response, []))
+
+    assert is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION) is expected
 
 
-def test_is_recorded_in_db_filters_on_all_three_fields(
+def test_record_in_db_creates_the_record_despite_an_unrelated_node(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    calls: list[str] = []
+    """The create must still run when the workspace holds only other images."""
+    calls: list[tuple[str, Any]] = []
     monkeypatch.setattr(
-        private_images, "execute", fake_execute({"nodes": [RECORDED_NODE]}, calls)
+        private_images, "execute", fake_execute({"nodes": [OTHER_IMAGE_NODE]}, calls)
     )
 
-    is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION)
+    record_in_db(WS_ID, IMAGE_NAME, VERSION)
 
-    assert len(calls) == 1
-    for field in ["workspaceId", "imageName", "version"]:
-        assert field in calls[0]
-
-
-@pytest.mark.parametrize("response", [{"nodes": []}, {"nodes": None}, None])
-def test_is_recorded_in_db_reports_a_missing_image(
-    monkeypatch: pytest.MonkeyPatch, response: Optional[dict[str, Any]]
-):
-    calls: list[str] = []
-    monkeypatch.setattr(private_images, "execute", fake_execute(response, calls))
-
-    assert is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION) is False
+    assert len(calls) == 2
+    assert "createPrivateImage" in calls[1][0]
 
 
 def test_record_in_db_skips_the_mutation_when_already_recorded(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """A retry of a partly completed upload must not hit the uniqueness constraint."""
-    calls: list[str] = []
+    calls: list[tuple[str, Any]] = []
     monkeypatch.setattr(
         private_images, "execute", fake_execute({"nodes": [RECORDED_NODE]}, calls)
     )
@@ -80,27 +106,29 @@ def test_record_in_db_skips_the_mutation_when_already_recorded(
     record_in_db(WS_ID, IMAGE_NAME, VERSION)
 
     assert len(calls) == 1
-    assert "createPrivateImage" not in calls[0]
+    assert "createPrivateImage" not in calls[0][0]
 
 
-def test_record_in_db_creates_the_record_when_missing(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    calls: list[str] = []
+def test_record_in_db_creates_the_record_when_missing(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[str, Any]] = []
     monkeypatch.setattr(private_images, "execute", fake_execute({"nodes": []}, calls))
 
     record_in_db(WS_ID, IMAGE_NAME, VERSION)
 
     assert len(calls) == 2
-    assert "createPrivateImage" in calls[1]
+    assert "createPrivateImage" in calls[1][0]
 
 
-def test_record_in_db_or_exit_is_silent_on_success(monkeypatch: pytest.MonkeyPatch):
+def test_record_in_db_or_exit_is_silent_on_success(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
     monkeypatch.setattr(
-        private_images, "record_in_db", lambda ws_id, image_name, version: None
+        private_images, "record_in_db", lambda _ws_id, _image_name, _version: None
     )
 
-    record_in_db_or_exit(WS_ID, IMAGE_NAME, VERSION, "ecr/image:abc123")
+    record_in_db_or_exit(WS_ID, IMAGE_NAME, VERSION, full_image_ref="ecr/image:abc123")
+
+    assert capsys.readouterr().out == ""
 
 
 def test_record_in_db_or_exit_uses_a_distinct_exit_code(
@@ -108,7 +136,7 @@ def test_record_in_db_or_exit_uses_a_distinct_exit_code(
 ):
     """A record failure must not look like a push failure, which exits 1."""
 
-    def raises(ws_id: str, image_name: str, version: str) -> None:
+    def raises(_ws_id: str, _image_name: str, _version: str) -> None:
         raise RuntimeError("uniqueness violation")
 
     monkeypatch.setattr(private_images, "record_in_db", raises)
@@ -116,11 +144,62 @@ def test_record_in_db_or_exit_uses_a_distinct_exit_code(
     full_image_ref = f"ecr/{IMAGE_NAME}:{VERSION}"
 
     with pytest.raises(click.exceptions.Exit) as excinfo:
-        record_in_db_or_exit(WS_ID, IMAGE_NAME, VERSION, full_image_ref)
+        record_in_db_or_exit(WS_ID, IMAGE_NAME, VERSION, full_image_ref=full_image_ref)
 
-    assert excinfo.value.exit_code == record_failed_exit_code
-    assert excinfo.value.exit_code != 1
+    # the literal is the promise to callers; asserting the constant is self-referential
+    assert excinfo.value.exit_code == 3
+    assert record_failed_exit_code == 3
 
     out = capsys.readouterr().out
     assert full_image_ref in out
     assert "uniqueness violation" in out
+
+
+def test_record_in_db_or_exit_passes_through_a_click_exit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A click exit from below must keep its own code, not be relabelled as 3."""
+
+    def raises(_ws_id: str, _image_name: str, _version: str) -> None:
+        raise click.exceptions.Exit(1)
+
+    monkeypatch.setattr(private_images, "record_in_db", raises)
+
+    with pytest.raises(click.exceptions.Exit) as excinfo:
+        record_in_db_or_exit(
+            WS_ID, IMAGE_NAME, VERSION, full_image_ref="ecr/image:abc123"
+        )
+
+    assert excinfo.value.exit_code == 1
+
+
+def test_record_failure_message_survives_a_multiline_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """A multi-line error must not defeat the dedent and skew the whole message."""
+
+    def raises(_ws_id: str, _image_name: str, _version: str) -> None:
+        raise RuntimeError("Transport error:\n{'message': 'duplicate key'}")
+
+    monkeypatch.setattr(private_images, "record_in_db", raises)
+
+    with pytest.raises(click.exceptions.Exit):
+        record_in_db_or_exit(
+            WS_ID, IMAGE_NAME, VERSION, full_image_ref="ecr/image:abc123"
+        )
+
+    out = capsys.readouterr().out
+    assert out.startswith("The image reached the registry")
+    # every line of the template is flush left; only the error body is indented
+    assert "\n`ecr/image:abc123` is pushed" in out
+
+
+def test_is_recorded_in_db_sends_all_three_variables(monkeypatch: pytest.MonkeyPatch):
+    calls: list[tuple[str, Any]] = []
+    monkeypatch.setattr(
+        private_images, "execute", fake_execute({"nodes": [RECORDED_NODE]}, calls)
+    )
+
+    is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION)
+
+    assert calls[0][1] == {"wsId": WS_ID, "imageName": IMAGE_NAME, "version": VERSION}

--- a/tests/test_private_images.py
+++ b/tests/test_private_images.py
@@ -1,0 +1,126 @@
+from typing import Any, Optional
+
+import click
+import graphql
+import pytest
+
+from latch_cli.services import private_images
+from latch_cli.services.private_images import (
+    is_recorded_in_db,
+    record_failed_exit_code,
+    record_in_db,
+    record_in_db_or_exit,
+)
+
+WS_ID = "1234"
+IMAGE_NAME = "1234_barcode_tools"
+VERSION = "abc123"
+
+RECORDED_NODE = {
+    "imageName": IMAGE_NAME,
+    "version": VERSION,
+    "creationTime": "2026-08-12T00:00:00Z",
+}
+
+
+def fake_execute(response: Optional[dict[str, Any]], calls: list[str]):
+    """Return a stand-in for `execute` that records the operation of each call."""
+
+    def execute(document: graphql.DocumentNode, variables=None, **kwargs):
+        calls.append(graphql.print_ast(document))
+
+        return {"privateImages": response}
+
+    return execute
+
+
+def test_is_recorded_in_db_finds_the_image(monkeypatch: pytest.MonkeyPatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        private_images, "execute", fake_execute({"nodes": [RECORDED_NODE]}, calls)
+    )
+
+    assert is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION) is True
+
+
+def test_is_recorded_in_db_filters_on_all_three_fields(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        private_images, "execute", fake_execute({"nodes": [RECORDED_NODE]}, calls)
+    )
+
+    is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION)
+
+    assert len(calls) == 1
+    for field in ["workspaceId", "imageName", "version"]:
+        assert field in calls[0]
+
+
+@pytest.mark.parametrize("response", [{"nodes": []}, {"nodes": None}, None])
+def test_is_recorded_in_db_reports_a_missing_image(
+    monkeypatch: pytest.MonkeyPatch, response: Optional[dict[str, Any]]
+):
+    calls: list[str] = []
+    monkeypatch.setattr(private_images, "execute", fake_execute(response, calls))
+
+    assert is_recorded_in_db(WS_ID, IMAGE_NAME, VERSION) is False
+
+
+def test_record_in_db_skips_the_mutation_when_already_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A retry of a partly completed upload must not hit the uniqueness constraint."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        private_images, "execute", fake_execute({"nodes": [RECORDED_NODE]}, calls)
+    )
+
+    record_in_db(WS_ID, IMAGE_NAME, VERSION)
+
+    assert len(calls) == 1
+    assert "createPrivateImage" not in calls[0]
+
+
+def test_record_in_db_creates_the_record_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[str] = []
+    monkeypatch.setattr(private_images, "execute", fake_execute({"nodes": []}, calls))
+
+    record_in_db(WS_ID, IMAGE_NAME, VERSION)
+
+    assert len(calls) == 2
+    assert "createPrivateImage" in calls[1]
+
+
+def test_record_in_db_or_exit_is_silent_on_success(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        private_images, "record_in_db", lambda ws_id, image_name, version: None
+    )
+
+    record_in_db_or_exit(WS_ID, IMAGE_NAME, VERSION, "ecr/image:abc123")
+
+
+def test_record_in_db_or_exit_uses_a_distinct_exit_code(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """A record failure must not look like a push failure, which exits 1."""
+
+    def raises(ws_id: str, image_name: str, version: str) -> None:
+        raise RuntimeError("uniqueness violation")
+
+    monkeypatch.setattr(private_images, "record_in_db", raises)
+
+    full_image_ref = f"ecr/{IMAGE_NAME}:{VERSION}"
+
+    with pytest.raises(click.exceptions.Exit) as excinfo:
+        record_in_db_or_exit(WS_ID, IMAGE_NAME, VERSION, full_image_ref)
+
+    assert excinfo.value.exit_code == record_failed_exit_code
+    assert excinfo.value.exit_code != 1
+
+    out = capsys.readouterr().out
+    assert full_image_ref in out
+    assert "uniqueness violation" in out


### PR DESCRIPTION
A published-but-unrecorded image previously exited with the push failure code (1), so a retry hit the database uniqueness constraint. The record step is now idempotent and reports its own exit code.

**Changes**
- Give a failed database record a distinct exit code (3); a failed push stays 1.
- Skip the create when the image is already recorded, matching image and version.
- Give the image-exists query its own TypedDict instead of sharing the `ls` type.
- Normalize the `workspaceId` value before the client-side match so it holds whether the API serializes it as a string or a number.

**Tests:** record-vs-push exit codes, idempotent create, and the exit/abort passthrough paths.

> **Stacked on `am_image_push_errors`.** Opened against `main` because that is the only base available cross-fork; against `main` this diff also includes the commits from the PRs below it. Retarget to `am_image_push_errors` once that branch exists upstream.
