### PR TITLE
feat(image): make image upload idempotent (skip if already recorded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Types of changes
 
 # Latch SDK Changelog
 
+## 2.77.1 - 2026-08-24
+
+### Changed
+
+* `latch image upload` now skips when the image and version are already recorded, so re-runs
+  are idempotent instead of failing on a re-push to the immutable registry
+
 ## 2.77.0 - 2026-08-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["src/**/*.py", "src/**/*.graphql", "src/**/py.typed", "src/latch_cli/
 
 [project]
 name = "latch"
-version = "2.77.0"
+version = "2.77.1"
 description = "The Latch SDK"
 authors = [{ name = "Kenny Workman", email = "kenny@latch.bio" }]
 maintainers = [{ name = "Kenny Workman", email = "kenny@latch.bio" }]

--- a/src/latch_cli/services/private_images.py
+++ b/src/latch_cli/services/private_images.py
@@ -338,6 +338,12 @@ def upload_image(
 
     full_image_ref = f"{ecr_base}/{namespaced_image_name}:{version}"
 
+    # a re-push of an already-recorded tag can only fail on the immutable registry, so
+    # skip it here, before the local-image inspect, so a re-run needs no local image
+    if is_recorded_in_db(ws_id, namespaced_image_name, version):
+        click.secho(f"{full_image_ref} is already published; skipping.", fg="green")
+        return
+
     client = get_local_docker_client()
 
     # resolve the source before we prompt: the user should be confirming a known

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def _upload_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     monkeypatch.setattr(private_images, "record_in_db_or_exit", lambda *_a, **_k: None)
+    monkeypatch.setattr(private_images, "is_recorded_in_db", lambda *_a, **_k: False)
 
 
 @pytest.fixture

--- a/tests/test_private_images.py
+++ b/tests/test_private_images.py
@@ -491,8 +491,9 @@ def test_upload_skips_when_already_recorded(
     client = _LocalImageClient()
     monkeypatch.setattr(private_images, "get_local_docker_client", lambda: client)
 
-    private_images.upload_image("team/tool:v1", skip_confirmation=True)
+    result = private_images.upload_image("team/tool:v1", skip_confirmation=True)
 
+    assert result is None
     assert client.pushed == []
     assert recorded is False
     assert "already published" in capsys.readouterr().out
@@ -506,8 +507,9 @@ def test_upload_skips_before_requiring_a_local_image(monkeypatch: pytest.MonkeyP
     client = _MissingImageClient()
     monkeypatch.setattr(private_images, "get_local_docker_client", lambda: client)
 
-    private_images.upload_image("team/tool:v1", skip_confirmation=True)
+    result = private_images.upload_image("team/tool:v1", skip_confirmation=True)
 
+    assert result is None
     assert client.pushed == []
     assert client.pulled == []
 

--- a/tests/test_private_images.py
+++ b/tests/test_private_images.py
@@ -378,6 +378,7 @@ def test_upload_image_uses_the_workspace_for_every_consumer(
     monkeypatch.setattr(private_images, "get_local_docker_client", lambda: client)
     monkeypatch.setattr(private_images, "print_upload_logs", lambda *_a, **_k: None)
     monkeypatch.setattr(private_images, "record_in_db_or_exit", record)
+    monkeypatch.setattr(private_images, "is_recorded_in_db", lambda *_a, **_k: False)
 
     private_images.upload_image(
         "some_registry/image:v1", workspace_id=OTHER_WS, skip_confirmation=True
@@ -471,6 +472,44 @@ def test_a_local_image_never_pulls(monkeypatch: pytest.MonkeyPatch):
 
     assert client.pulled == []
     assert client.pushed == [f"{private_images.ecr_base}/{WS_ID}_tool"]
+
+
+@pytest.mark.usefixtures("_upload_stubs", "_quiet_upload_logs")
+def test_upload_skips_when_already_recorded(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """A re-run of an already-recorded publish must not push or record again."""
+    monkeypatch.setattr(private_images, "is_recorded_in_db", lambda *_a, **_k: True)
+    recorded = False
+
+    def record(*_args: object, **_kwargs: object) -> None:
+        nonlocal recorded
+        recorded = True
+
+    monkeypatch.setattr(private_images, "record_in_db_or_exit", record)
+
+    client = _LocalImageClient()
+    monkeypatch.setattr(private_images, "get_local_docker_client", lambda: client)
+
+    private_images.upload_image("team/tool:v1", skip_confirmation=True)
+
+    assert client.pushed == []
+    assert recorded is False
+    assert "already published" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("_upload_stubs", "_quiet_upload_logs")
+def test_upload_skips_before_requiring_a_local_image(monkeypatch: pytest.MonkeyPatch):
+    """The skip must short-circuit before the local-image guard would exit(1)."""
+    monkeypatch.setattr(private_images, "is_recorded_in_db", lambda *_a, **_k: True)
+
+    client = _MissingImageClient()
+    monkeypatch.setattr(private_images, "get_local_docker_client", lambda: client)
+
+    private_images.upload_image("team/tool:v1", skip_confirmation=True)
+
+    assert client.pushed == []
+    assert client.pulled == []
 
 
 def _stub_ls_response(

--- a/uv.lock
+++ b/uv.lock
@@ -1292,7 +1292,7 @@ wheels = [
 
 [[package]]
 name = "latch"
-version = "2.76.10"
+version = "2.77.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Previously, `upload_image` pushed unconditionally, so re-publishing an already-recorded image fails when the immutable Latch ECR rejects the re-push.

Now, it skips when `is_recorded_in_db(ws_id, namespaced_image_name, version)` is true. Records are only written after a confirmed push, so "recorded" means "published"; skipping is always safe, and a re-run needn't have the image built locally.

No flag (a re-push to the immutable registry can only fail).

Bumps to 2.77.1 + CHANGELOG.