### PR TITLE
deps: bump GitPython to 3.1.61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "python-dateutil>=2.8",
   "pydantic>=2,<3",
   "rich>=14.0.0",
-  "GitPython==3.1.40",
+  "GitPython==3.1.61",
   # for old latch develop, to be removed
   "asyncssh==2.13.2",
   "websockets>=11,<16",

--- a/uv.lock
+++ b/uv.lock
@@ -860,14 +860,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.40"
+version = "3.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/b2/37265877ae607a2cbf9a471f4581dbf5ed13a501b90cb4c773f9ccfff3ea/GitPython-3.1.40.tar.gz", hash = "sha256:22b126e9ffb671fdd0c129796343a02bf67bf2994b35449ffc9321aa755e18a4", size = 200655, upload-time = "2023-10-18T15:28:40.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/61/3285044215fb596bf093e39ccb96ece0a1076a8ca57a61e069a6a33cdb1b/gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95", size = 231680, upload-time = "2026-08-28T11:01:13.761889Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/c4/82b858fb6483dfb5e338123c154d19c043305b01726a67d89532b8f8f01b/GitPython-3.1.40-py3-none-any.whl", hash = "sha256:cf14627d5a8049ffbf49915732e5eddbe8134c3bdb9d476e6182b676fc573f8a", size = 190573, upload-time = "2023-10-18T15:28:36.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/49cc172da4d0578644ba37cec5cb365b1fefc603b26edea9bcac1c7f830a/gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c", size = 222118, upload-time = "2026-08-28T11:01:12.262613Z" },
 ]
 
 [[package]]
@@ -1362,7 +1362,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "dill", specifier = ">=0.4.0" },
     { name = "docker", specifier = ">=7.1.0" },
-    { name = "gitpython", specifier = "==3.1.40" },
+    { name = "gitpython", specifier = "==3.1.61" },
     { name = "gql", specifier = "==3.5.0" },
     { name = "graphql-core", specifier = "==3.2.3" },
     { name = "kubernetes", specifier = ">=24.2.0" },


### PR DESCRIPTION
Updates `GitPython` to address GHSA-284h-m62q-gf8w (critical, CVSS 9.8), GHSA-8mcc-hrx5-hvxc, and GHSA-7833-fr7j-v32q.

Evidence:
- `pyproject.toml` pinned `GitPython==3.1.40`
- OSV (api.osv.dev) reports 44 advisories for GitPython 3.1.40, including GHSA-284h-m62q-gf8w, GHSA-8mcc-hrx5-hvxc, GHSA-7833-fr7j-v32q
- updated version: `3.1.61`

Validation:
- OSV reports zero advisories for GitPython 3.1.61 (clears every GitPython advisory, not just the three above)
- `pytest -s tests` (from the Justfile): 68 passed. One collection error in `tests/test_ls.py::test_ls` because it needs a `TEST_TOKEN` env var; unrelated to this change
- `uv sync --frozen` succeeds against the edited lockfile

Note: `uv lock --check` fails on the base branch too. The lockfile was already out of sync with `pyproject.toml` before this change, so this PR hand-edits only the gitpython entries (version, specifier, sdist/wheel URL, hash, size from PyPI) instead of regenerating the whole file.

Scope: dependency/lockfile update only.
